### PR TITLE
chore: Update descriptions for conditions

### DIFF
--- a/dist/workflow_step_template_schema.json
+++ b/dist/workflow_step_template_schema.json
@@ -1578,7 +1578,7 @@
             "if": {
                 "type": "object",
                 "title": "If-Then-Else  Flow",
-                "description": "A conditional flow of steps or nested flow control schemas. In the well\nknown if-then-else fashion a conditional flow through the workflow can be\nimplemented.\n",
+                "description": "A conditional flow of steps or nested flow control schemas. In the well known if-then-else fashion a conditional flow through the workflow can be implemented.\n",
                 "required": [
                     "if",
                     "then"
@@ -1587,7 +1587,7 @@
                 "properties": {
                     "if": {
                         "$ref": "#/definitions/script",
-                        "description": "The condition has access to all fields of the workflow. Any string\nresult or numerical result other then zero will be considered truthy and\ntrigger execution of the `then` workflow. A falsy value will trigger\nexecution of the `else` workflow.\n"
+                        "description": "The condition has access to all global fields of the workflow. Local step fields cannot be referenced in a condition. Any string result or numerical result other then zero will be considered truthy and trigger execution of the `then` workflow. A falsy value will trigger execution of the `else` workflow.\n"
                     },
                     "then": {
                         "$ref": "#/definitions/flow/flowControl"
@@ -1614,7 +1614,7 @@
             "loop": {
                 "type": "object",
                 "title": "Loop Flow",
-                "description": "A loop flow of steps or nested flow control schemas. The loop will be\nrepeated until a condition is met. The loop will be executed at least once.\nOnce the condition evaluates to a truthy value the loop is broken and the\nloop flow is considered completed.\n",
+                "description": "A loop flow of steps or nested flow control schemas. The loop will be repeated until a condition is met. The loop will be executed at least once. Once the condition evaluates to a truthy value the loop is broken and the loop flow is considered completed.\n",
                 "required": [
                     "loop",
                     "until"
@@ -1626,7 +1626,7 @@
                     },
                     "until": {
                         "$ref": "#/definitions/script",
-                        "description": "The condition has access to all fields of the workflow. Any string\nresult or numerical result other then zero will be considered truthy and\ntrigger completion of the loop flow. A falsy value will trigger\nanother iteration of the `loop` workflow.\n"
+                        "description": "The condition has access to all global fields of the workflow. Local step fields cannot be referenced in a condition. Any string result or numerical result other then zero will be considered truthy and trigger execution of the `then` workflow. A falsy value will trigger execution of the `else` workflow.\n"
                     }
                 },
                 "examples": [
@@ -1705,7 +1705,7 @@
             "while": {
                 "type": "object",
                 "title": "While Flow",
-                "description": "A while loop flow of steps or nested flow control schemas. The while loop\nwill be repeated as long as a condition is met. The while loop will never be\nexecuted if the conditions evaluates to false initially. Once the condition\nevaluates to a falsy value the loop is broken and the while loop flow is\nconsidered completed.\n",
+                "description": "A while loop flow of steps or nested flow control schemas. The while loop will be repeated as long as a condition is met. The while loop will never be executed if the conditions evaluates to false initially. Once the condition evaluates to a falsy value the loop is broken and the while loop flow is considered completed.\n",
                 "required": [
                     "while",
                     "do"
@@ -1714,7 +1714,7 @@
                 "properties": {
                     "while": {
                         "$ref": "#/definitions/script",
-                        "description": "The condition has access to all fields of the workflow. Any string\nresult or numerical result other then zero will be considered truthy and\ntrigger another iteration of the `do` flow. A falsy value will trigger\ncompletion of the while loop flow.\n"
+                        "description": "The condition has access to all global fields of the workflow. Local step fields cannot be referenced in a condition. Any string result or numerical result other then zero will be considered truthy and trigger execution of the `then` workflow. A falsy value will trigger execution of the `else` workflow.\n"
                     },
                     "do": {
                         "$ref": "#/definitions/flow/flowControl"

--- a/dist/workflow_template_schema.json
+++ b/dist/workflow_template_schema.json
@@ -1603,7 +1603,7 @@
             "if": {
                 "type": "object",
                 "title": "If-Then-Else  Flow",
-                "description": "A conditional flow of steps or nested flow control schemas. In the well\nknown if-then-else fashion a conditional flow through the workflow can be\nimplemented.\n",
+                "description": "A conditional flow of steps or nested flow control schemas. In the well known if-then-else fashion a conditional flow through the workflow can be implemented.\n",
                 "required": [
                     "if",
                     "then"
@@ -1612,7 +1612,7 @@
                 "properties": {
                     "if": {
                         "$ref": "#/definitions/script",
-                        "description": "The condition has access to all fields of the workflow. Any string\nresult or numerical result other then zero will be considered truthy and\ntrigger execution of the `then` workflow. A falsy value will trigger\nexecution of the `else` workflow.\n"
+                        "description": "The condition has access to all global fields of the workflow. Local step fields cannot be referenced in a condition. Any string result or numerical result other then zero will be considered truthy and trigger execution of the `then` workflow. A falsy value will trigger execution of the `else` workflow.\n"
                     },
                     "then": {
                         "$ref": "#/definitions/flow/flowControl"
@@ -1639,7 +1639,7 @@
             "loop": {
                 "type": "object",
                 "title": "Loop Flow",
-                "description": "A loop flow of steps or nested flow control schemas. The loop will be\nrepeated until a condition is met. The loop will be executed at least once.\nOnce the condition evaluates to a truthy value the loop is broken and the\nloop flow is considered completed.\n",
+                "description": "A loop flow of steps or nested flow control schemas. The loop will be repeated until a condition is met. The loop will be executed at least once. Once the condition evaluates to a truthy value the loop is broken and the loop flow is considered completed.\n",
                 "required": [
                     "loop",
                     "until"
@@ -1651,7 +1651,7 @@
                     },
                     "until": {
                         "$ref": "#/definitions/script",
-                        "description": "The condition has access to all fields of the workflow. Any string\nresult or numerical result other then zero will be considered truthy and\ntrigger completion of the loop flow. A falsy value will trigger\nanother iteration of the `loop` workflow.\n"
+                        "description": "The condition has access to all global fields of the workflow. Local step fields cannot be referenced in a condition. Any string result or numerical result other then zero will be considered truthy and trigger execution of the `then` workflow. A falsy value will trigger execution of the `else` workflow.\n"
                     }
                 },
                 "examples": [
@@ -1730,7 +1730,7 @@
             "while": {
                 "type": "object",
                 "title": "While Flow",
-                "description": "A while loop flow of steps or nested flow control schemas. The while loop\nwill be repeated as long as a condition is met. The while loop will never be\nexecuted if the conditions evaluates to false initially. Once the condition\nevaluates to a falsy value the loop is broken and the while loop flow is\nconsidered completed.\n",
+                "description": "A while loop flow of steps or nested flow control schemas. The while loop will be repeated as long as a condition is met. The while loop will never be executed if the conditions evaluates to false initially. Once the condition evaluates to a falsy value the loop is broken and the while loop flow is considered completed.\n",
                 "required": [
                     "while",
                     "do"
@@ -1739,7 +1739,7 @@
                 "properties": {
                     "while": {
                         "$ref": "#/definitions/script",
-                        "description": "The condition has access to all fields of the workflow. Any string\nresult or numerical result other then zero will be considered truthy and\ntrigger another iteration of the `do` flow. A falsy value will trigger\ncompletion of the while loop flow.\n"
+                        "description": "The condition has access to all global fields of the workflow. Local step fields cannot be referenced in a condition. Any string result or numerical result other then zero will be considered truthy and trigger execution of the `then` workflow. A falsy value will trigger execution of the `else` workflow.\n"
                     },
                     "do": {
                         "$ref": "#/definitions/flow/flowControl"

--- a/src/schemata/definitions/flow/if.yml
+++ b/src/schemata/definitions/flow/if.yml
@@ -2,19 +2,14 @@
 type: object
 title: If-Then-Else  Flow
 description: |
-  A conditional flow of steps or nested flow control schemas. In the well
-  known if-then-else fashion a conditional flow through the workflow can be
-  implemented.
+  A conditional flow of steps or nested flow control schemas. In the well known if-then-else fashion a conditional flow through the workflow can be implemented.
 required: [if, then]
 additionalProperties: false
 properties:
   if:
     $ref: '#/definitions/script'
     description: |
-      The condition has access to all fields of the workflow. Any string
-      result or numerical result other then zero will be considered truthy and
-      trigger execution of the `then` workflow. A falsy value will trigger
-      execution of the `else` workflow.
+      The condition has access to all global fields of the workflow. Local step fields cannot be referenced in a condition. Any string result or numerical result other then zero will be considered truthy and trigger execution of the `then` workflow. A falsy value will trigger execution of the `else` workflow.
   then:
     $ref: '#/definitions/flow/flowControl'
   else:

--- a/src/schemata/definitions/flow/loop.yml
+++ b/src/schemata/definitions/flow/loop.yml
@@ -2,10 +2,7 @@
 type: object
 title: Loop Flow
 description: |
-  A loop flow of steps or nested flow control schemas. The loop will be
-  repeated until a condition is met. The loop will be executed at least once.
-  Once the condition evaluates to a truthy value the loop is broken and the
-  loop flow is considered completed.
+  A loop flow of steps or nested flow control schemas. The loop will be repeated until a condition is met. The loop will be executed at least once. Once the condition evaluates to a truthy value the loop is broken and the loop flow is considered completed.
 required: [loop, until]
 additionalProperties: false
 properties:
@@ -14,10 +11,7 @@ properties:
   until:
     $ref: '#/definitions/script'
     description: |
-      The condition has access to all fields of the workflow. Any string
-      result or numerical result other then zero will be considered truthy and
-      trigger completion of the loop flow. A falsy value will trigger
-      another iteration of the `loop` workflow.
+      The condition has access to all global fields of the workflow. Local step fields cannot be referenced in a condition. Any string result or numerical result other then zero will be considered truthy and trigger execution of the `then` workflow. A falsy value will trigger execution of the `else` workflow.
 examples:
   - loop:
       - step1

--- a/src/schemata/definitions/flow/while.yml
+++ b/src/schemata/definitions/flow/while.yml
@@ -2,21 +2,14 @@
 type: object
 title: While Flow
 description: |
-  A while loop flow of steps or nested flow control schemas. The while loop
-  will be repeated as long as a condition is met. The while loop will never be
-  executed if the conditions evaluates to false initially. Once the condition
-  evaluates to a falsy value the loop is broken and the while loop flow is
-  considered completed.
+  A while loop flow of steps or nested flow control schemas. The while loop will be repeated as long as a condition is met. The while loop will never be executed if the conditions evaluates to false initially. Once the condition evaluates to a falsy value the loop is broken and the while loop flow is considered completed.
 required: [while, do]
 additionalProperties: false
 properties:
   while:
     $ref: '#/definitions/script'
     description: |
-      The condition has access to all fields of the workflow. Any string
-      result or numerical result other then zero will be considered truthy and
-      trigger another iteration of the `do` flow. A falsy value will trigger
-      completion of the while loop flow.
+      The condition has access to all global fields of the workflow. Local step fields cannot be referenced in a condition. Any string result or numerical result other then zero will be considered truthy and trigger execution of the `then` workflow. A falsy value will trigger execution of the `else` workflow.
   do:
     $ref: '#/definitions/flow/flowControl'
 examples:

--- a/src/workflow_step_template_schema.json
+++ b/src/workflow_step_template_schema.json
@@ -1578,7 +1578,7 @@
       "if": {
         "type": "object",
         "title": "If-Then-Else  Flow",
-        "description": "A conditional flow of steps or nested flow control schemas. In the well\nknown if-then-else fashion a conditional flow through the workflow can be\nimplemented.\n",
+        "description": "A conditional flow of steps or nested flow control schemas. In the well known if-then-else fashion a conditional flow through the workflow can be implemented.\n",
         "required": [
           "if",
           "then"
@@ -1587,7 +1587,7 @@
         "properties": {
           "if": {
             "$ref": "#/definitions/script",
-            "description": "The condition has access to all fields of the workflow. Any string\nresult or numerical result other then zero will be considered truthy and\ntrigger execution of the `then` workflow. A falsy value will trigger\nexecution of the `else` workflow.\n"
+            "description": "The condition has access to all global fields of the workflow. Local step fields cannot be referenced in a condition. Any string result or numerical result other then zero will be considered truthy and trigger execution of the `then` workflow. A falsy value will trigger execution of the `else` workflow.\n"
           },
           "then": {
             "$ref": "#/definitions/flow/flowControl"
@@ -1614,7 +1614,7 @@
       "loop": {
         "type": "object",
         "title": "Loop Flow",
-        "description": "A loop flow of steps or nested flow control schemas. The loop will be\nrepeated until a condition is met. The loop will be executed at least once.\nOnce the condition evaluates to a truthy value the loop is broken and the\nloop flow is considered completed.\n",
+        "description": "A loop flow of steps or nested flow control schemas. The loop will be repeated until a condition is met. The loop will be executed at least once. Once the condition evaluates to a truthy value the loop is broken and the loop flow is considered completed.\n",
         "required": [
           "loop",
           "until"
@@ -1626,7 +1626,7 @@
           },
           "until": {
             "$ref": "#/definitions/script",
-            "description": "The condition has access to all fields of the workflow. Any string\nresult or numerical result other then zero will be considered truthy and\ntrigger completion of the loop flow. A falsy value will trigger\nanother iteration of the `loop` workflow.\n"
+            "description": "The condition has access to all global fields of the workflow. Local step fields cannot be referenced in a condition. Any string result or numerical result other then zero will be considered truthy and trigger execution of the `then` workflow. A falsy value will trigger execution of the `else` workflow.\n"
           }
         },
         "examples": [
@@ -1705,7 +1705,7 @@
       "while": {
         "type": "object",
         "title": "While Flow",
-        "description": "A while loop flow of steps or nested flow control schemas. The while loop\nwill be repeated as long as a condition is met. The while loop will never be\nexecuted if the conditions evaluates to false initially. Once the condition\nevaluates to a falsy value the loop is broken and the while loop flow is\nconsidered completed.\n",
+        "description": "A while loop flow of steps or nested flow control schemas. The while loop will be repeated as long as a condition is met. The while loop will never be executed if the conditions evaluates to false initially. Once the condition evaluates to a falsy value the loop is broken and the while loop flow is considered completed.\n",
         "required": [
           "while",
           "do"
@@ -1714,7 +1714,7 @@
         "properties": {
           "while": {
             "$ref": "#/definitions/script",
-            "description": "The condition has access to all fields of the workflow. Any string\nresult or numerical result other then zero will be considered truthy and\ntrigger another iteration of the `do` flow. A falsy value will trigger\ncompletion of the while loop flow.\n"
+            "description": "The condition has access to all global fields of the workflow. Local step fields cannot be referenced in a condition. Any string result or numerical result other then zero will be considered truthy and trigger execution of the `then` workflow. A falsy value will trigger execution of the `else` workflow.\n"
           },
           "do": {
             "$ref": "#/definitions/flow/flowControl"

--- a/src/workflow_template_schema.json
+++ b/src/workflow_template_schema.json
@@ -1603,7 +1603,7 @@
       "if": {
         "type": "object",
         "title": "If-Then-Else  Flow",
-        "description": "A conditional flow of steps or nested flow control schemas. In the well\nknown if-then-else fashion a conditional flow through the workflow can be\nimplemented.\n",
+        "description": "A conditional flow of steps or nested flow control schemas. In the well known if-then-else fashion a conditional flow through the workflow can be implemented.\n",
         "required": [
           "if",
           "then"
@@ -1612,7 +1612,7 @@
         "properties": {
           "if": {
             "$ref": "#/definitions/script",
-            "description": "The condition has access to all fields of the workflow. Any string\nresult or numerical result other then zero will be considered truthy and\ntrigger execution of the `then` workflow. A falsy value will trigger\nexecution of the `else` workflow.\n"
+            "description": "The condition has access to all global fields of the workflow. Local step fields cannot be referenced in a condition. Any string result or numerical result other then zero will be considered truthy and trigger execution of the `then` workflow. A falsy value will trigger execution of the `else` workflow.\n"
           },
           "then": {
             "$ref": "#/definitions/flow/flowControl"
@@ -1639,7 +1639,7 @@
       "loop": {
         "type": "object",
         "title": "Loop Flow",
-        "description": "A loop flow of steps or nested flow control schemas. The loop will be\nrepeated until a condition is met. The loop will be executed at least once.\nOnce the condition evaluates to a truthy value the loop is broken and the\nloop flow is considered completed.\n",
+        "description": "A loop flow of steps or nested flow control schemas. The loop will be repeated until a condition is met. The loop will be executed at least once. Once the condition evaluates to a truthy value the loop is broken and the loop flow is considered completed.\n",
         "required": [
           "loop",
           "until"
@@ -1651,7 +1651,7 @@
           },
           "until": {
             "$ref": "#/definitions/script",
-            "description": "The condition has access to all fields of the workflow. Any string\nresult or numerical result other then zero will be considered truthy and\ntrigger completion of the loop flow. A falsy value will trigger\nanother iteration of the `loop` workflow.\n"
+            "description": "The condition has access to all global fields of the workflow. Local step fields cannot be referenced in a condition. Any string result or numerical result other then zero will be considered truthy and trigger execution of the `then` workflow. A falsy value will trigger execution of the `else` workflow.\n"
           }
         },
         "examples": [
@@ -1730,7 +1730,7 @@
       "while": {
         "type": "object",
         "title": "While Flow",
-        "description": "A while loop flow of steps or nested flow control schemas. The while loop\nwill be repeated as long as a condition is met. The while loop will never be\nexecuted if the conditions evaluates to false initially. Once the condition\nevaluates to a falsy value the loop is broken and the while loop flow is\nconsidered completed.\n",
+        "description": "A while loop flow of steps or nested flow control schemas. The while loop will be repeated as long as a condition is met. The while loop will never be executed if the conditions evaluates to false initially. Once the condition evaluates to a falsy value the loop is broken and the while loop flow is considered completed.\n",
         "required": [
           "while",
           "do"
@@ -1739,7 +1739,7 @@
         "properties": {
           "while": {
             "$ref": "#/definitions/script",
-            "description": "The condition has access to all fields of the workflow. Any string\nresult or numerical result other then zero will be considered truthy and\ntrigger another iteration of the `do` flow. A falsy value will trigger\ncompletion of the while loop flow.\n"
+            "description": "The condition has access to all global fields of the workflow. Local step fields cannot be referenced in a condition. Any string result or numerical result other then zero will be considered truthy and trigger execution of the `then` workflow. A falsy value will trigger execution of the `else` workflow.\n"
           },
           "do": {
             "$ref": "#/definitions/flow/flowControl"


### PR DESCRIPTION
![](https://i.kym-cdn.com/entries/icons/mobile/000/028/007/Screen_Shot_2018-12-31_at_1.19.26_PM.jpg)

While maybe not literally wrong, the current wording is ambiguous at best and implies that all fields of the template can be referenced.
