### PR TITLE
[WFE-245] Assert min and max character length in member name regex pattern

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 
 - [[CUB-4303]](https://labforward.atlassian.net/browse/CUB-4303) [Workflows] Update get resources template schema
+- [[CUB-245]](https://labforward.atlassian.net/browse/WFE-245) [Documentation] Assert min and max character length in member name regex pattern
 
 ### Deprecated
 

--- a/dist/workflow_step_template_schema.json
+++ b/dist/workflow_step_template_schema.json
@@ -690,7 +690,7 @@
             "description": "A member name that is used as a reference elsewhere.\nAllowed characters are lower \"a\" to \"z\", capital \"A\" to \"Z\", \"0\" to \"9\" and\n\"-\" , \"_\". We recommend to consistently use either lowerCamelCase or\nkebab-case. While snake_case is allowed, it has a chance of name collisions\nwith internal values.\n",
             "minLength": 3,
             "maxLength": 60,
-            "pattern": "^[a-zA-Z0-9]+(?:[-_]?[a-zA-Z0-9]+)*$",
+            "pattern": "(?=^.{3,60}$)(^[a-zA-Z0-9]+(?:[-_]?[a-zA-Z0-9]+)*$)",
             "not": {
                 "enum": [
                     "command_response",

--- a/dist/workflow_template_schema.json
+++ b/dist/workflow_template_schema.json
@@ -715,7 +715,7 @@
             "description": "A member name that is used as a reference elsewhere.\nAllowed characters are lower \"a\" to \"z\", capital \"A\" to \"Z\", \"0\" to \"9\" and\n\"-\" , \"_\". We recommend to consistently use either lowerCamelCase or\nkebab-case. While snake_case is allowed, it has a chance of name collisions\nwith internal values.\n",
             "minLength": 3,
             "maxLength": 60,
-            "pattern": "^[a-zA-Z0-9]+(?:[-_]?[a-zA-Z0-9]+)*$",
+            "pattern": "(?=^.{3,60}$)(^[a-zA-Z0-9]+(?:[-_]?[a-zA-Z0-9]+)*$)",
             "not": {
                 "enum": [
                     "command_response",

--- a/src/schemata/definitions/member_name.yml
+++ b/src/schemata/definitions/member_name.yml
@@ -9,7 +9,7 @@ description: |
   with internal values.
 minLength: 3
 maxLength: 60
-pattern: ^[a-zA-Z0-9]+(?:[-_]?[a-zA-Z0-9]+)*$
+pattern: (?=^.{3,60}$)(^[a-zA-Z0-9]+(?:[-_]?[a-zA-Z0-9]+)*$)
 not:
   enum:
     - command_response

--- a/src/workflow_step_template_schema.json
+++ b/src/workflow_step_template_schema.json
@@ -690,7 +690,7 @@
       "description": "A member name that is used as a reference elsewhere.\nAllowed characters are lower \"a\" to \"z\", capital \"A\" to \"Z\", \"0\" to \"9\" and\n\"-\" , \"_\". We recommend to consistently use either lowerCamelCase or\nkebab-case. While snake_case is allowed, it has a chance of name collisions\nwith internal values.\n",
       "minLength": 3,
       "maxLength": 60,
-      "pattern": "^[a-zA-Z0-9]+(?:[-_]?[a-zA-Z0-9]+)*$",
+      "pattern": "(?=^.{3,60}$)(^[a-zA-Z0-9]+(?:[-_]?[a-zA-Z0-9]+)*$)",
       "not": {
         "enum": [
           "command_response",

--- a/src/workflow_template_schema.json
+++ b/src/workflow_template_schema.json
@@ -715,7 +715,7 @@
       "description": "A member name that is used as a reference elsewhere.\nAllowed characters are lower \"a\" to \"z\", capital \"A\" to \"Z\", \"0\" to \"9\" and\n\"-\" , \"_\". We recommend to consistently use either lowerCamelCase or\nkebab-case. While snake_case is allowed, it has a chance of name collisions\nwith internal values.\n",
       "minLength": 3,
       "maxLength": 60,
-      "pattern": "^[a-zA-Z0-9]+(?:[-_]?[a-zA-Z0-9]+)*$",
+      "pattern": "(?=^.{3,60}$)(^[a-zA-Z0-9]+(?:[-_]?[a-zA-Z0-9]+)*$)",
       "not": {
         "enum": [
           "command_response",


### PR DESCRIPTION
### [WFE-245]

### Description

<details>
<summary>regex</summary>

![normal-regex](https://user-images.githubusercontent.com/42832087/191827701-58516ce8-d30f-47a3-9ddc-a8d4e68c2130.png)

</details>

The schema is already validating this correctly based on the `minLength` and `maxLength` properties, but the WFE relies on the pattern to validate member name strings.

### Manual PR Checklist

- [x] CHANGELOG entry added
- [x] ~Test coverage added~
- [x] ~Licenses checked~
- [x] All related Jira tickets added to PR title
- [x] Description in Jira ticket is clear and up-to-date


[WFE-245]: https://labforward.atlassian.net/browse/WFE-245?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ