### PR TITLE
Fixed settings for license checker workflow

### DIFF
--- a/.github/workflows/license_checker.yml
+++ b/.github/workflows/license_checker.yml
@@ -1,7 +1,7 @@
 name: License Checker
 on:
   pull_request:
-    branches: [main]
+    branches: [develop]
 jobs:
   license-check:
     runs-on: ubuntu-latest


### PR DESCRIPTION
The branch was mistakenly set to `main` instead of `develop`