### PR TITLE
[chore] Fix small typos in Change Reason and Substep schemas

### DIFF
--- a/dist/workflow_step_template_schema.json
+++ b/dist/workflow_step_template_schema.json
@@ -2036,7 +2036,7 @@
             },
             "substep": {
                 "type": "object",
-                "title": "Substeps Schema",
+                "title": "Substep Schema",
                 "description": "A substep is a single instruction of a step and can both content and actions\nattached to it.\n",
                 "required": [
                     "primary"
@@ -3079,7 +3079,7 @@
                             "message": {
                                 "type": "string",
                                 "maxLength": 1000,
-                                "default": "This field is flagged as an change reason field. To update the field with a new value, a reason must be submitted.\n",
+                                "default": "This field is flagged as a change reason field. To update the field with a new value, a reason must be submitted.\n",
                                 "description": "A message that appears in the reason dialog to provide additional information to the user and to make sure a valid reason is entered.\n\nThe default message is translated according to the user profile's language setting.\n"
                             },
                             "validation": {

--- a/dist/workflow_template_schema.json
+++ b/dist/workflow_template_schema.json
@@ -2061,7 +2061,7 @@
             },
             "substep": {
                 "type": "object",
-                "title": "Substeps Schema",
+                "title": "Substep Schema",
                 "description": "A substep is a single instruction of a step and can both content and actions\nattached to it.\n",
                 "required": [
                     "primary"
@@ -3104,7 +3104,7 @@
                             "message": {
                                 "type": "string",
                                 "maxLength": 1000,
-                                "default": "This field is flagged as an change reason field. To update the field with a new value, a reason must be submitted.\n",
+                                "default": "This field is flagged as a change reason field. To update the field with a new value, a reason must be submitted.\n",
                                 "description": "A message that appears in the reason dialog to provide additional information to the user and to make sure a valid reason is entered.\n\nThe default message is translated according to the user profile's language setting.\n"
                             },
                             "validation": {

--- a/src/schemata/definitions/step/substep.yml
+++ b/src/schemata/definitions/step/substep.yml
@@ -1,6 +1,6 @@
 ---
 type: object
-title: Substeps Schema
+title: Substep Schema
 description: |
   A substep is a single instruction of a step and can both content and actions
   attached to it.

--- a/src/schemata/definitions/workflow_template/changeReason.yml
+++ b/src/schemata/definitions/workflow_template/changeReason.yml
@@ -30,7 +30,7 @@ oneOf:
         type: string
         maxLength: 1000
         default: |
-          This field is flagged as an change reason field. To update the field with a new value, a reason must be submitted.
+          This field is flagged as a change reason field. To update the field with a new value, a reason must be submitted.
         description: |
           A message that appears in the reason dialog to provide additional information to the user and to make sure a valid reason is entered.
 

--- a/src/workflow_step_template_schema.json
+++ b/src/workflow_step_template_schema.json
@@ -2036,7 +2036,7 @@
       },
       "substep": {
         "type": "object",
-        "title": "Substeps Schema",
+        "title": "Substep Schema",
         "description": "A substep is a single instruction of a step and can both content and actions\nattached to it.\n",
         "required": [
           "primary"
@@ -3079,7 +3079,7 @@
               "message": {
                 "type": "string",
                 "maxLength": 1000,
-                "default": "This field is flagged as an change reason field. To update the field with a new value, a reason must be submitted.\n",
+                "default": "This field is flagged as a change reason field. To update the field with a new value, a reason must be submitted.\n",
                 "description": "A message that appears in the reason dialog to provide additional information to the user and to make sure a valid reason is entered.\n\nThe default message is translated according to the user profile's language setting.\n"
               },
               "validation": {

--- a/src/workflow_template_schema.json
+++ b/src/workflow_template_schema.json
@@ -2061,7 +2061,7 @@
       },
       "substep": {
         "type": "object",
-        "title": "Substeps Schema",
+        "title": "Substep Schema",
         "description": "A substep is a single instruction of a step and can both content and actions\nattached to it.\n",
         "required": [
           "primary"
@@ -3104,7 +3104,7 @@
               "message": {
                 "type": "string",
                 "maxLength": 1000,
-                "default": "This field is flagged as an change reason field. To update the field with a new value, a reason must be submitted.\n",
+                "default": "This field is flagged as a change reason field. To update the field with a new value, a reason must be submitted.\n",
                 "description": "A message that appears in the reason dialog to provide additional information to the user and to make sure a valid reason is entered.\n\nThe default message is translated according to the user profile's language setting.\n"
               },
               "validation": {


### PR DESCRIPTION
`"Substeps Schema"` => `"Substep schema"`
`"This field is flagged as an change reason field"` => `"This field is flagged as a change reason field"`