### PR TITLE
[chore] Update media types definition for field with type file 

### DIFF
--- a/dist/workflow_step_template_schema.json
+++ b/dist/workflow_step_template_schema.json
@@ -1312,18 +1312,8 @@
                         ]
                     },
                     "mediaType": {
-                        "description": "A single or list of accepted [Media Types](https://www.iana.org/assignments/media-types/media-types.xhtml).\n\nNote: Not all Media Types out there might be supported.\n",
-                        "oneOf": [
-                            {
-                                "type": "string"
-                            },
-                            {
-                                "type": "array",
-                                "items": {
-                                    "type": "string"
-                                }
-                            }
-                        ]
+                        "description": "The media format of the specific file. Kindly see the accepted [Media Types](https://www.iana.org/assignments/media-types/media-types.xhtml).\n\nNote: Not all Media Types out there might be supported.\n",
+                        "type": "string"
                     }
                 }
             },

--- a/dist/workflow_step_template_schema.json
+++ b/dist/workflow_step_template_schema.json
@@ -1312,7 +1312,7 @@
                         ]
                     },
                     "mediaType": {
-                        "description": "The media format of the specific file. Kindly see the accepted [Media Types](https://www.iana.org/assignments/media-types/media-types.xhtml).\n\nNote: Not all Media Types out there might be supported.\n",
+                        "description": "A [media type](https://www.iana.org/assignments/media-types/media-types.xhtml) is a two-part identifier for file formats and format contents. Note that not all possible media types might be supported.\n",
                         "type": "string"
                     }
                 }

--- a/dist/workflow_step_template_schema.json
+++ b/dist/workflow_step_template_schema.json
@@ -1315,7 +1315,17 @@
                         "description": "A [media type](https://www.iana.org/assignments/media-types/media-types.xhtml) is a two-part identifier for file formats and format contents. Note that not all possible media types might be supported.\n",
                         "type": "string"
                     }
-                }
+                },
+                "examples": [
+                    {
+                        "type": "file",
+                        "mediaType": "application/pdf"
+                    },
+                    {
+                        "type": "file",
+                        "mediaType": "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+                    }
+                ]
             },
             "quantity": {
                 "type": "object",

--- a/dist/workflow_template_schema.json
+++ b/dist/workflow_template_schema.json
@@ -1340,7 +1340,17 @@
                         "description": "A [media type](https://www.iana.org/assignments/media-types/media-types.xhtml) is a two-part identifier for file formats and format contents. Note that not all possible media types might be supported.\n",
                         "type": "string"
                     }
-                }
+                },
+                "examples": [
+                    {
+                        "type": "file",
+                        "mediaType": "application/pdf"
+                    },
+                    {
+                        "type": "file",
+                        "mediaType": "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+                    }
+                ]
             },
             "quantity": {
                 "type": "object",

--- a/dist/workflow_template_schema.json
+++ b/dist/workflow_template_schema.json
@@ -1337,18 +1337,8 @@
                         ]
                     },
                     "mediaType": {
-                        "description": "A single or list of accepted [Media Types](https://www.iana.org/assignments/media-types/media-types.xhtml).\n\nNote: Not all Media Types out there might be supported.\n",
-                        "oneOf": [
-                            {
-                                "type": "string"
-                            },
-                            {
-                                "type": "array",
-                                "items": {
-                                    "type": "string"
-                                }
-                            }
-                        ]
+                        "description": "The media format of the specific file. Kindly see the accepted [Media Types](https://www.iana.org/assignments/media-types/media-types.xhtml).\n\nNote: Not all Media Types out there might be supported.\n",
+                        "type": "string"
                     }
                 }
             },

--- a/dist/workflow_template_schema.json
+++ b/dist/workflow_template_schema.json
@@ -1337,7 +1337,7 @@
                         ]
                     },
                     "mediaType": {
-                        "description": "The media format of the specific file. Kindly see the accepted [Media Types](https://www.iana.org/assignments/media-types/media-types.xhtml).\n\nNote: Not all Media Types out there might be supported.\n",
+                        "description": "A [media type](https://www.iana.org/assignments/media-types/media-types.xhtml) is a two-part identifier for file formats and format contents. Note that not all possible media types might be supported.\n",
                         "type": "string"
                     }
                 }

--- a/src/schemata/definitions/field_schema/file.yml
+++ b/src/schemata/definitions/field_schema/file.yml
@@ -9,11 +9,7 @@ properties:
     enum: [file]
   mediaType:
     description: |
-      A single or list of accepted [Media Types](https://www.iana.org/assignments/media-types/media-types.xhtml).
+      The media format of the specific file. Kindly see the accepted [Media Types](https://www.iana.org/assignments/media-types/media-types.xhtml).
 
       Note: Not all Media Types out there might be supported.
-    oneOf:
-      - type: string
-      - type: array
-        items:
-          type: string
+    type: string

--- a/src/schemata/definitions/field_schema/file.yml
+++ b/src/schemata/definitions/field_schema/file.yml
@@ -11,3 +11,8 @@ properties:
     description: |
       A [media type](https://www.iana.org/assignments/media-types/media-types.xhtml) is a two-part identifier for file formats and format contents. Note that not all possible media types might be supported.
     type: string
+examples:
+  - type: file
+    mediaType: application/pdf
+  - type: file
+    mediaType: application/vnd.openxmlformats-officedocument.wordprocessingml.document

--- a/src/schemata/definitions/field_schema/file.yml
+++ b/src/schemata/definitions/field_schema/file.yml
@@ -9,7 +9,5 @@ properties:
     enum: [file]
   mediaType:
     description: |
-      The media format of the specific file. Kindly see the accepted [Media Types](https://www.iana.org/assignments/media-types/media-types.xhtml).
-
-      Note: Not all Media Types out there might be supported.
+      A [media type](https://www.iana.org/assignments/media-types/media-types.xhtml) is a two-part identifier for file formats and format contents. Note that not all possible media types might be supported.
     type: string

--- a/src/workflow_step_template_schema.json
+++ b/src/workflow_step_template_schema.json
@@ -1312,18 +1312,8 @@
             ]
           },
           "mediaType": {
-            "description": "A single or list of accepted [Media Types](https://www.iana.org/assignments/media-types/media-types.xhtml).\n\nNote: Not all Media Types out there might be supported.\n",
-            "oneOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "array",
-                "items": {
-                  "type": "string"
-                }
-              }
-            ]
+            "description": "The media format of the specific file. Kindly see the accepted [Media Types](https://www.iana.org/assignments/media-types/media-types.xhtml).\n\nNote: Not all Media Types out there might be supported.\n",
+            "type": "string"
           }
         }
       },

--- a/src/workflow_step_template_schema.json
+++ b/src/workflow_step_template_schema.json
@@ -1315,7 +1315,17 @@
             "description": "A [media type](https://www.iana.org/assignments/media-types/media-types.xhtml) is a two-part identifier for file formats and format contents. Note that not all possible media types might be supported.\n",
             "type": "string"
           }
-        }
+        },
+        "examples": [
+          {
+            "type": "file",
+            "mediaType": "application/pdf"
+          },
+          {
+            "type": "file",
+            "mediaType": "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+          }
+        ]
       },
       "quantity": {
         "type": "object",

--- a/src/workflow_step_template_schema.json
+++ b/src/workflow_step_template_schema.json
@@ -1312,7 +1312,7 @@
             ]
           },
           "mediaType": {
-            "description": "The media format of the specific file. Kindly see the accepted [Media Types](https://www.iana.org/assignments/media-types/media-types.xhtml).\n\nNote: Not all Media Types out there might be supported.\n",
+            "description": "A [media type](https://www.iana.org/assignments/media-types/media-types.xhtml) is a two-part identifier for file formats and format contents. Note that not all possible media types might be supported.\n",
             "type": "string"
           }
         }

--- a/src/workflow_template_schema.json
+++ b/src/workflow_template_schema.json
@@ -1337,18 +1337,8 @@
             ]
           },
           "mediaType": {
-            "description": "A single or list of accepted [Media Types](https://www.iana.org/assignments/media-types/media-types.xhtml).\n\nNote: Not all Media Types out there might be supported.\n",
-            "oneOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "array",
-                "items": {
-                  "type": "string"
-                }
-              }
-            ]
+            "description": "The media format of the specific file. Kindly see the accepted [Media Types](https://www.iana.org/assignments/media-types/media-types.xhtml).\n\nNote: Not all Media Types out there might be supported.\n",
+            "type": "string"
           }
         }
       },

--- a/src/workflow_template_schema.json
+++ b/src/workflow_template_schema.json
@@ -1340,7 +1340,17 @@
             "description": "A [media type](https://www.iana.org/assignments/media-types/media-types.xhtml) is a two-part identifier for file formats and format contents. Note that not all possible media types might be supported.\n",
             "type": "string"
           }
-        }
+        },
+        "examples": [
+          {
+            "type": "file",
+            "mediaType": "application/pdf"
+          },
+          {
+            "type": "file",
+            "mediaType": "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+          }
+        ]
       },
       "quantity": {
         "type": "object",

--- a/src/workflow_template_schema.json
+++ b/src/workflow_template_schema.json
@@ -1337,7 +1337,7 @@
             ]
           },
           "mediaType": {
-            "description": "The media format of the specific file. Kindly see the accepted [Media Types](https://www.iana.org/assignments/media-types/media-types.xhtml).\n\nNote: Not all Media Types out there might be supported.\n",
+            "description": "A [media type](https://www.iana.org/assignments/media-types/media-types.xhtml) is a two-part identifier for file formats and format contents. Note that not all possible media types might be supported.\n",
             "type": "string"
           }
         }


### PR DESCRIPTION
[chore]

Currently, we specify that `mediaType` can be a list of strings or a string. This is inconsequential since only the first element in the list is considered if a list of strings is passed in the actual workflow (step) templates. To this end,  we are updating the file definition for `mediaType` to be only a string type to avoid unnecessary confusion.

