### PR TITLE
[CHORE] Update definition for Timer fields

### DIFF
--- a/dist/workflow_step_template_schema.json
+++ b/dist/workflow_step_template_schema.json
@@ -1674,18 +1674,6 @@
                         "default": false,
                         "description": "A flag indicating whether to skip automatically creating behaviors to\nhandle buttons on the timer.\n",
                         "markdownDescription": "A flag indicating whether to skip automatically creating behaviors to\nhandle buttons on the timer.\n\n\nSee more: [Timer Schema](https://schema.laboperator.com/schemas/definitions/field_schema/timer) "
-                    },
-                    "editable": {
-                        "type": "boolean",
-                        "default": false,
-                        "description": "A flag indicating whether the duration can be manually adjusted at\nruntime.\n",
-                        "markdownDescription": "A flag indicating whether the duration can be manually adjusted at\nruntime.\n\n\nSee more: [Timer Schema](https://schema.laboperator.com/schemas/definitions/field_schema/timer) "
-                    },
-                    "playSound": {
-                        "type": "boolean",
-                        "default": false,
-                        "description": "A flag indicating whether the timer should trigger a sound when\ngoing off. The sound can always be toggled at runtime.\n",
-                        "markdownDescription": "A flag indicating whether the timer should trigger a sound when\ngoing off. The sound can always be toggled at runtime.\n\n\nSee more: [Timer Schema](https://schema.laboperator.com/schemas/definitions/field_schema/timer) "
                     }
                 },
                 "markdownDescription": "Defines a field of type `timer`. Timers are used to measure time or execute time-controlled actions within a Workflow Run.\n\nTimers have two possible modes of operation: countdown and stopwatch.\n\nIn **countdown** mode, the timer will run for a specified duration, and fire a `on_timer_complete` Trigger upon completion.\nIn **stopwatch** mode, the timer measures time until it is stopped, either manually or through a Behavior.\n\nTimer fields can be assigned to individual substeps by passing the field identifier to the `timer` property.\n\n\nSee more: [Timer Schema](https://schema.laboperator.com/schemas/definitions/field_schema/timer) "

--- a/dist/workflow_step_template_schema.json
+++ b/dist/workflow_step_template_schema.json
@@ -1629,7 +1629,7 @@
             },
             "timer": {
                 "type": "object",
-                "description": "Defines a field of type `timer`. Timers are used to measure time or execute time-controlled actions within a Workflow Run.\n\nTimers have two possible modes of operation: countdown and stopwatch.\n\nIn **countdown** mode, the timer will run for a specified duration, and fire a `on_timer_complete` Trigger upon completion.\nIn **stopwatch** mode, the timer measures time until it is stopped, either manually or through a Behavior.\n\nTimer fields can be assigned to individual substeps by passing the field identifier to the `timer` property.\n",
+                "description": "Defines a field of type `timer` to measure time or execute time-controlled actions.\n\nTimers have two possible modes of operation, countdown and stopwatch. In countdown mode, the timer will run for a specified duration and fire a [Timer Complete trigger](/schemas/definitions/workflow_template/trigger_objects/timerComplete/) upon completion. In _stopwatch_ mode, the timer measures time until it is stopped, either manually or through an [action](/schemas/definitions/workflow_template/actions/).\n",
                 "required": [
                     "type"
                 ],
@@ -1641,15 +1641,20 @@
                         ]
                     },
                     "defaultDuration": {
-                        "description": "The default value set on the timer upon starting the workflow. If this is defined, the timer will run in countdown mode, unless the value is reset during workflow execution.\n\nThe initial value of the timer can also be set using the `defaultValue` property. If both are defined, `defaultValue` will overwrite the value set in `defaultDuration`.\n",
                         "$ref": "#/definitions/duration",
-                        "markdownDescription": "The default value set on the timer upon starting the workflow. If this is defined, the timer will run in countdown mode, unless the value is reset during workflow execution.\n\nThe initial value of the timer can also be set using the `defaultValue` property. If both are defined, `defaultValue` will overwrite the value set in `defaultDuration`.\n\n\nSee more: [Timer Schema](https://schema.laboperator.com/schemas/definitions/field_schema/timer) "
+                        "description": "The default value of the timer. If set to a non-zero value, the timer will run in countdown mode. If no duration is defined or it is set to _\"0:00\"_, the timer will run in stopwatch mode. Note that also defining `defaultValue` will overwrite this setting.\n",
+                        "examples": [
+                            90,
+                            "1 mins 30 sec",
+                            "1:30"
+                        ],
+                        "markdownDescription": "The default value of the timer. If set to a non-zero value, the timer will run in countdown mode. If no duration is defined or it is set to _\"0:00\"_, the timer will run in stopwatch mode. Note that also defining `defaultValue` will overwrite this setting.\n\n\nSee more: [Timer Schema](https://schema.laboperator.com/schemas/definitions/field_schema/timer) "
                     },
                     "showButtons": {
                         "type": "boolean",
                         "default": false,
-                        "description": "A flag indicating whether to show all the buttons to control the timer. When this property is set to `true`, it will take precedence over the flags for individual buttons.\n",
-                        "markdownDescription": "A flag indicating whether to show all the buttons to control the timer. When this property is set to `true`, it will take precedence over the flags for individual buttons.\n\n\nSee more: [Timer Schema](https://schema.laboperator.com/schemas/definitions/field_schema/timer) "
+                        "description": "A flag indicating whether to show all timer control buttons. Use this setting to conveniently remove all buttons in case of the timer being controlled entirely by [actions](/schemas/definitions/workflow_template/actions/). This setting take precedence over the settings for the individual buttons.\n",
+                        "markdownDescription": "A flag indicating whether to show all timer control buttons. Use this setting to conveniently remove all buttons in case of the timer being controlled entirely by [actions](https://schema.laboperator.com/schemas/definitions/workflow_template/actions/). This setting take precedence over the settings for the individual buttons.\n\n\nSee more: [Timer Schema](https://schema.laboperator.com/schemas/definitions/field_schema/timer) "
                     },
                     "showStartButton": {
                         "type": "boolean",
@@ -1672,8 +1677,8 @@
                     "skipBehaviors": {
                         "type": "boolean",
                         "default": false,
-                        "description": "A flag indicating whether to skip automatically creating behaviors to\nhandle buttons on the timer.\n",
-                        "markdownDescription": "A flag indicating whether to skip automatically creating behaviors to\nhandle buttons on the timer.\n\n\nSee more: [Timer Schema](https://schema.laboperator.com/schemas/definitions/field_schema/timer) "
+                        "description": "A flag indicating whether to skip automatically creating behaviors to\nhandle the control button, e.g. starting the countdown.\n",
+                        "markdownDescription": "A flag indicating whether to skip automatically creating behaviors to\nhandle the control button, e.g. starting the countdown.\n\n\nSee more: [Timer Schema](https://schema.laboperator.com/schemas/definitions/field_schema/timer) "
                     }
                 },
                 "examples": [
@@ -1689,7 +1694,7 @@
                         "showResetButton": true
                     }
                 ],
-                "markdownDescription": "Defines a field of type `timer`. Timers are used to measure time or execute time-controlled actions within a Workflow Run.\n\nTimers have two possible modes of operation: countdown and stopwatch.\n\nIn **countdown** mode, the timer will run for a specified duration, and fire a `on_timer_complete` Trigger upon completion.\nIn **stopwatch** mode, the timer measures time until it is stopped, either manually or through a Behavior.\n\nTimer fields can be assigned to individual substeps by passing the field identifier to the `timer` property.\n\n\nSee more: [Timer Schema](https://schema.laboperator.com/schemas/definitions/field_schema/timer) "
+                "markdownDescription": "Defines a field of type `timer` to measure time or execute time-controlled actions.\n\nTimers have two possible modes of operation, countdown and stopwatch. In countdown mode, the timer will run for a specified duration and fire a [Timer Complete trigger](https://schema.laboperator.com/schemas/definitions/workflow_template/trigger_objects/timerComplete/) upon completion. In _stopwatch_ mode, the timer measures time until it is stopped, either manually or through an [action](/schemas/definitions/workflow_template/actions/).\n\n\nSee more: [Timer Schema](https://schema.laboperator.com/schemas/definitions/field_schema/timer) "
             }
         },
         "flow": {

--- a/dist/workflow_step_template_schema.json
+++ b/dist/workflow_step_template_schema.json
@@ -1629,7 +1629,7 @@
             },
             "timer": {
                 "type": "object",
-                "description": "Defines a field of type `timer`.\n",
+                "description": "Defines a field of type `timer`. Timers are used to measure time or execute time-controlled actions within a Workflow Run.\n\nTimers have two possible modes of operation: countdown and stopwatch.\n\nIn **countdown** mode, the timer will run for a specified duration, and fire a `on_timer_complete` Trigger upon completion.\nIn **stopwatch** mode, the timer measures time until it is stopped, either manually or through a Behavior.\n\nTimer fields can be assigned to individual substeps by passing the field identifier to the `timer` property.\n",
                 "required": [
                     "type"
                 ],
@@ -1641,33 +1641,33 @@
                         ]
                     },
                     "defaultDuration": {
-                        "description": "A fixed duration.",
+                        "description": "The default value set on the timer upon starting the workflow. If this is defined, the timer will run in countdown mode, unless the value is reset during workflow execution.\n\nThe initial value of the timer can also be set using the `defaultValue` property. If both are defined, `defaultValue` will overwrite the value set in `defaultDuration`.\n",
                         "$ref": "#/definitions/duration",
-                        "markdownDescription": "A fixed duration.\n\nSee more: [Timer Schema](https://schema.laboperator.com/schemas/definitions/field_schema/timer) "
+                        "markdownDescription": "The default value set on the timer upon starting the workflow. If this is defined, the timer will run in countdown mode, unless the value is reset during workflow execution.\n\nThe initial value of the timer can also be set using the `defaultValue` property. If both are defined, `defaultValue` will overwrite the value set in `defaultDuration`.\n\n\nSee more: [Timer Schema](https://schema.laboperator.com/schemas/definitions/field_schema/timer) "
                     },
                     "showButtons": {
                         "type": "boolean",
-                        "default": true,
-                        "description": "A flag indicating whether to show the buttons.",
-                        "markdownDescription": "A flag indicating whether to show the buttons.\n\nSee more: [Timer Schema](https://schema.laboperator.com/schemas/definitions/field_schema/timer) "
+                        "default": false,
+                        "description": "A flag indicating whether to show all the buttons to control the timer. When this property is set to `true`, it will take precedence over the flags for individual buttons.\n",
+                        "markdownDescription": "A flag indicating whether to show all the buttons to control the timer. When this property is set to `true`, it will take precedence over the flags for individual buttons.\n\n\nSee more: [Timer Schema](https://schema.laboperator.com/schemas/definitions/field_schema/timer) "
                     },
                     "showStartButton": {
                         "type": "boolean",
-                        "default": true,
-                        "description": "A flag indicating whether to show the start button.",
-                        "markdownDescription": "A flag indicating whether to show the start button.\n\nSee more: [Timer Schema](https://schema.laboperator.com/schemas/definitions/field_schema/timer) "
+                        "default": false,
+                        "description": "A flag indicating whether to show the start button.\n",
+                        "markdownDescription": "A flag indicating whether to show the start button.\n\n\nSee more: [Timer Schema](https://schema.laboperator.com/schemas/definitions/field_schema/timer) "
                     },
-                    "showPauseButton": {
+                    "showStopButton": {
                         "type": "boolean",
-                        "default": true,
-                        "description": "A flag indicating whether to show the pause button.",
-                        "markdownDescription": "A flag indicating whether to show the pause button.\n\nSee more: [Timer Schema](https://schema.laboperator.com/schemas/definitions/field_schema/timer) "
+                        "default": false,
+                        "description": "A flag indicating whether to show the stop button.\n",
+                        "markdownDescription": "A flag indicating whether to show the stop button.\n\n\nSee more: [Timer Schema](https://schema.laboperator.com/schemas/definitions/field_schema/timer) "
                     },
-                    "showCancelButton": {
+                    "showResetButton": {
                         "type": "boolean",
-                        "default": true,
-                        "description": "A flag indicating whether to show the cancel button.",
-                        "markdownDescription": "A flag indicating whether to show the cancel button.\n\nSee more: [Timer Schema](https://schema.laboperator.com/schemas/definitions/field_schema/timer) "
+                        "default": false,
+                        "description": "A flag indicating whether to show the reset button.\n",
+                        "markdownDescription": "A flag indicating whether to show the reset button.\n\n\nSee more: [Timer Schema](https://schema.laboperator.com/schemas/definitions/field_schema/timer) "
                     },
                     "skipBehaviors": {
                         "type": "boolean",
@@ -1688,7 +1688,7 @@
                         "markdownDescription": "A flag indicating whether the timer should trigger a sound when\ngoing off. The sound can always be toggled at runtime.\n\n\nSee more: [Timer Schema](https://schema.laboperator.com/schemas/definitions/field_schema/timer) "
                     }
                 },
-                "markdownDescription": "Defines a field of type `timer`.\n\n\nSee more: [Timer Schema](https://schema.laboperator.com/schemas/definitions/field_schema/timer) "
+                "markdownDescription": "Defines a field of type `timer`. Timers are used to measure time or execute time-controlled actions within a Workflow Run.\n\nTimers have two possible modes of operation: countdown and stopwatch.\n\nIn **countdown** mode, the timer will run for a specified duration, and fire a `on_timer_complete` Trigger upon completion.\nIn **stopwatch** mode, the timer measures time until it is stopped, either manually or through a Behavior.\n\nTimer fields can be assigned to individual substeps by passing the field identifier to the `timer` property.\n\n\nSee more: [Timer Schema](https://schema.laboperator.com/schemas/definitions/field_schema/timer) "
             }
         },
         "flow": {

--- a/dist/workflow_step_template_schema.json
+++ b/dist/workflow_step_template_schema.json
@@ -1676,6 +1676,19 @@
                         "markdownDescription": "A flag indicating whether to skip automatically creating behaviors to\nhandle buttons on the timer.\n\n\nSee more: [Timer Schema](https://schema.laboperator.com/schemas/definitions/field_schema/timer) "
                     }
                 },
+                "examples": [
+                    {
+                        "type": "timer",
+                        "defaultDuration": "120 seconds",
+                        "showButtons": true
+                    },
+                    {
+                        "type": "timer",
+                        "skipBehaviors": true,
+                        "showStartButton": true,
+                        "showResetButton": true
+                    }
+                ],
                 "markdownDescription": "Defines a field of type `timer`. Timers are used to measure time or execute time-controlled actions within a Workflow Run.\n\nTimers have two possible modes of operation: countdown and stopwatch.\n\nIn **countdown** mode, the timer will run for a specified duration, and fire a `on_timer_complete` Trigger upon completion.\nIn **stopwatch** mode, the timer measures time until it is stopped, either manually or through a Behavior.\n\nTimer fields can be assigned to individual substeps by passing the field identifier to the `timer` property.\n\n\nSee more: [Timer Schema](https://schema.laboperator.com/schemas/definitions/field_schema/timer) "
             }
         },

--- a/dist/workflow_template_schema.json
+++ b/dist/workflow_template_schema.json
@@ -1699,18 +1699,6 @@
                         "default": false,
                         "description": "A flag indicating whether to skip automatically creating behaviors to\nhandle buttons on the timer.\n",
                         "markdownDescription": "A flag indicating whether to skip automatically creating behaviors to\nhandle buttons on the timer.\n\n\nSee more: [Timer Schema](https://schema.laboperator.com/schemas/definitions/field_schema/timer) "
-                    },
-                    "editable": {
-                        "type": "boolean",
-                        "default": false,
-                        "description": "A flag indicating whether the duration can be manually adjusted at\nruntime.\n",
-                        "markdownDescription": "A flag indicating whether the duration can be manually adjusted at\nruntime.\n\n\nSee more: [Timer Schema](https://schema.laboperator.com/schemas/definitions/field_schema/timer) "
-                    },
-                    "playSound": {
-                        "type": "boolean",
-                        "default": false,
-                        "description": "A flag indicating whether the timer should trigger a sound when\ngoing off. The sound can always be toggled at runtime.\n",
-                        "markdownDescription": "A flag indicating whether the timer should trigger a sound when\ngoing off. The sound can always be toggled at runtime.\n\n\nSee more: [Timer Schema](https://schema.laboperator.com/schemas/definitions/field_schema/timer) "
                     }
                 },
                 "markdownDescription": "Defines a field of type `timer`. Timers are used to measure time or execute time-controlled actions within a Workflow Run.\n\nTimers have two possible modes of operation: countdown and stopwatch.\n\nIn **countdown** mode, the timer will run for a specified duration, and fire a `on_timer_complete` Trigger upon completion.\nIn **stopwatch** mode, the timer measures time until it is stopped, either manually or through a Behavior.\n\nTimer fields can be assigned to individual substeps by passing the field identifier to the `timer` property.\n\n\nSee more: [Timer Schema](https://schema.laboperator.com/schemas/definitions/field_schema/timer) "

--- a/dist/workflow_template_schema.json
+++ b/dist/workflow_template_schema.json
@@ -1701,6 +1701,19 @@
                         "markdownDescription": "A flag indicating whether to skip automatically creating behaviors to\nhandle buttons on the timer.\n\n\nSee more: [Timer Schema](https://schema.laboperator.com/schemas/definitions/field_schema/timer) "
                     }
                 },
+                "examples": [
+                    {
+                        "type": "timer",
+                        "defaultDuration": "120 seconds",
+                        "showButtons": true
+                    },
+                    {
+                        "type": "timer",
+                        "skipBehaviors": true,
+                        "showStartButton": true,
+                        "showResetButton": true
+                    }
+                ],
                 "markdownDescription": "Defines a field of type `timer`. Timers are used to measure time or execute time-controlled actions within a Workflow Run.\n\nTimers have two possible modes of operation: countdown and stopwatch.\n\nIn **countdown** mode, the timer will run for a specified duration, and fire a `on_timer_complete` Trigger upon completion.\nIn **stopwatch** mode, the timer measures time until it is stopped, either manually or through a Behavior.\n\nTimer fields can be assigned to individual substeps by passing the field identifier to the `timer` property.\n\n\nSee more: [Timer Schema](https://schema.laboperator.com/schemas/definitions/field_schema/timer) "
             }
         },

--- a/dist/workflow_template_schema.json
+++ b/dist/workflow_template_schema.json
@@ -1654,7 +1654,7 @@
             },
             "timer": {
                 "type": "object",
-                "description": "Defines a field of type `timer`.\n",
+                "description": "Defines a field of type `timer`. Timers are used to measure time or execute time-controlled actions within a Workflow Run.\n\nTimers have two possible modes of operation: countdown and stopwatch.\n\nIn **countdown** mode, the timer will run for a specified duration, and fire a `on_timer_complete` Trigger upon completion.\nIn **stopwatch** mode, the timer measures time until it is stopped, either manually or through a Behavior.\n\nTimer fields can be assigned to individual substeps by passing the field identifier to the `timer` property.\n",
                 "required": [
                     "type"
                 ],
@@ -1666,33 +1666,33 @@
                         ]
                     },
                     "defaultDuration": {
-                        "description": "A fixed duration.",
+                        "description": "The default value set on the timer upon starting the workflow. If this is defined, the timer will run in countdown mode, unless the value is reset during workflow execution.\n\nThe initial value of the timer can also be set using the `defaultValue` property. If both are defined, `defaultValue` will overwrite the value set in `defaultDuration`.\n",
                         "$ref": "#/definitions/duration",
-                        "markdownDescription": "A fixed duration.\n\nSee more: [Timer Schema](https://schema.laboperator.com/schemas/definitions/field_schema/timer) "
+                        "markdownDescription": "The default value set on the timer upon starting the workflow. If this is defined, the timer will run in countdown mode, unless the value is reset during workflow execution.\n\nThe initial value of the timer can also be set using the `defaultValue` property. If both are defined, `defaultValue` will overwrite the value set in `defaultDuration`.\n\n\nSee more: [Timer Schema](https://schema.laboperator.com/schemas/definitions/field_schema/timer) "
                     },
                     "showButtons": {
                         "type": "boolean",
-                        "default": true,
-                        "description": "A flag indicating whether to show the buttons.",
-                        "markdownDescription": "A flag indicating whether to show the buttons.\n\nSee more: [Timer Schema](https://schema.laboperator.com/schemas/definitions/field_schema/timer) "
+                        "default": false,
+                        "description": "A flag indicating whether to show all the buttons to control the timer. When this property is set to `true`, it will take precedence over the flags for individual buttons.\n",
+                        "markdownDescription": "A flag indicating whether to show all the buttons to control the timer. When this property is set to `true`, it will take precedence over the flags for individual buttons.\n\n\nSee more: [Timer Schema](https://schema.laboperator.com/schemas/definitions/field_schema/timer) "
                     },
                     "showStartButton": {
                         "type": "boolean",
-                        "default": true,
-                        "description": "A flag indicating whether to show the start button.",
-                        "markdownDescription": "A flag indicating whether to show the start button.\n\nSee more: [Timer Schema](https://schema.laboperator.com/schemas/definitions/field_schema/timer) "
+                        "default": false,
+                        "description": "A flag indicating whether to show the start button.\n",
+                        "markdownDescription": "A flag indicating whether to show the start button.\n\n\nSee more: [Timer Schema](https://schema.laboperator.com/schemas/definitions/field_schema/timer) "
                     },
-                    "showPauseButton": {
+                    "showStopButton": {
                         "type": "boolean",
-                        "default": true,
-                        "description": "A flag indicating whether to show the pause button.",
-                        "markdownDescription": "A flag indicating whether to show the pause button.\n\nSee more: [Timer Schema](https://schema.laboperator.com/schemas/definitions/field_schema/timer) "
+                        "default": false,
+                        "description": "A flag indicating whether to show the stop button.\n",
+                        "markdownDescription": "A flag indicating whether to show the stop button.\n\n\nSee more: [Timer Schema](https://schema.laboperator.com/schemas/definitions/field_schema/timer) "
                     },
-                    "showCancelButton": {
+                    "showResetButton": {
                         "type": "boolean",
-                        "default": true,
-                        "description": "A flag indicating whether to show the cancel button.",
-                        "markdownDescription": "A flag indicating whether to show the cancel button.\n\nSee more: [Timer Schema](https://schema.laboperator.com/schemas/definitions/field_schema/timer) "
+                        "default": false,
+                        "description": "A flag indicating whether to show the reset button.\n",
+                        "markdownDescription": "A flag indicating whether to show the reset button.\n\n\nSee more: [Timer Schema](https://schema.laboperator.com/schemas/definitions/field_schema/timer) "
                     },
                     "skipBehaviors": {
                         "type": "boolean",
@@ -1713,7 +1713,7 @@
                         "markdownDescription": "A flag indicating whether the timer should trigger a sound when\ngoing off. The sound can always be toggled at runtime.\n\n\nSee more: [Timer Schema](https://schema.laboperator.com/schemas/definitions/field_schema/timer) "
                     }
                 },
-                "markdownDescription": "Defines a field of type `timer`.\n\n\nSee more: [Timer Schema](https://schema.laboperator.com/schemas/definitions/field_schema/timer) "
+                "markdownDescription": "Defines a field of type `timer`. Timers are used to measure time or execute time-controlled actions within a Workflow Run.\n\nTimers have two possible modes of operation: countdown and stopwatch.\n\nIn **countdown** mode, the timer will run for a specified duration, and fire a `on_timer_complete` Trigger upon completion.\nIn **stopwatch** mode, the timer measures time until it is stopped, either manually or through a Behavior.\n\nTimer fields can be assigned to individual substeps by passing the field identifier to the `timer` property.\n\n\nSee more: [Timer Schema](https://schema.laboperator.com/schemas/definitions/field_schema/timer) "
             }
         },
         "flow": {

--- a/dist/workflow_template_schema.json
+++ b/dist/workflow_template_schema.json
@@ -1654,7 +1654,7 @@
             },
             "timer": {
                 "type": "object",
-                "description": "Defines a field of type `timer`. Timers are used to measure time or execute time-controlled actions within a Workflow Run.\n\nTimers have two possible modes of operation: countdown and stopwatch.\n\nIn **countdown** mode, the timer will run for a specified duration, and fire a `on_timer_complete` Trigger upon completion.\nIn **stopwatch** mode, the timer measures time until it is stopped, either manually or through a Behavior.\n\nTimer fields can be assigned to individual substeps by passing the field identifier to the `timer` property.\n",
+                "description": "Defines a field of type `timer` to measure time or execute time-controlled actions.\n\nTimers have two possible modes of operation, countdown and stopwatch. In countdown mode, the timer will run for a specified duration and fire a [Timer Complete trigger](/schemas/definitions/workflow_template/trigger_objects/timerComplete/) upon completion. In _stopwatch_ mode, the timer measures time until it is stopped, either manually or through an [action](/schemas/definitions/workflow_template/actions/).\n",
                 "required": [
                     "type"
                 ],
@@ -1666,15 +1666,20 @@
                         ]
                     },
                     "defaultDuration": {
-                        "description": "The default value set on the timer upon starting the workflow. If this is defined, the timer will run in countdown mode, unless the value is reset during workflow execution.\n\nThe initial value of the timer can also be set using the `defaultValue` property. If both are defined, `defaultValue` will overwrite the value set in `defaultDuration`.\n",
                         "$ref": "#/definitions/duration",
-                        "markdownDescription": "The default value set on the timer upon starting the workflow. If this is defined, the timer will run in countdown mode, unless the value is reset during workflow execution.\n\nThe initial value of the timer can also be set using the `defaultValue` property. If both are defined, `defaultValue` will overwrite the value set in `defaultDuration`.\n\n\nSee more: [Timer Schema](https://schema.laboperator.com/schemas/definitions/field_schema/timer) "
+                        "description": "The default value of the timer. If set to a non-zero value, the timer will run in countdown mode. If no duration is defined or it is set to _\"0:00\"_, the timer will run in stopwatch mode. Note that also defining `defaultValue` will overwrite this setting.\n",
+                        "examples": [
+                            90,
+                            "1 mins 30 sec",
+                            "1:30"
+                        ],
+                        "markdownDescription": "The default value of the timer. If set to a non-zero value, the timer will run in countdown mode. If no duration is defined or it is set to _\"0:00\"_, the timer will run in stopwatch mode. Note that also defining `defaultValue` will overwrite this setting.\n\n\nSee more: [Timer Schema](https://schema.laboperator.com/schemas/definitions/field_schema/timer) "
                     },
                     "showButtons": {
                         "type": "boolean",
                         "default": false,
-                        "description": "A flag indicating whether to show all the buttons to control the timer. When this property is set to `true`, it will take precedence over the flags for individual buttons.\n",
-                        "markdownDescription": "A flag indicating whether to show all the buttons to control the timer. When this property is set to `true`, it will take precedence over the flags for individual buttons.\n\n\nSee more: [Timer Schema](https://schema.laboperator.com/schemas/definitions/field_schema/timer) "
+                        "description": "A flag indicating whether to show all timer control buttons. Use this setting to conveniently remove all buttons in case of the timer being controlled entirely by [actions](/schemas/definitions/workflow_template/actions/). This setting take precedence over the settings for the individual buttons.\n",
+                        "markdownDescription": "A flag indicating whether to show all timer control buttons. Use this setting to conveniently remove all buttons in case of the timer being controlled entirely by [actions](https://schema.laboperator.com/schemas/definitions/workflow_template/actions/). This setting take precedence over the settings for the individual buttons.\n\n\nSee more: [Timer Schema](https://schema.laboperator.com/schemas/definitions/field_schema/timer) "
                     },
                     "showStartButton": {
                         "type": "boolean",
@@ -1697,8 +1702,8 @@
                     "skipBehaviors": {
                         "type": "boolean",
                         "default": false,
-                        "description": "A flag indicating whether to skip automatically creating behaviors to\nhandle buttons on the timer.\n",
-                        "markdownDescription": "A flag indicating whether to skip automatically creating behaviors to\nhandle buttons on the timer.\n\n\nSee more: [Timer Schema](https://schema.laboperator.com/schemas/definitions/field_schema/timer) "
+                        "description": "A flag indicating whether to skip automatically creating behaviors to\nhandle the control button, e.g. starting the countdown.\n",
+                        "markdownDescription": "A flag indicating whether to skip automatically creating behaviors to\nhandle the control button, e.g. starting the countdown.\n\n\nSee more: [Timer Schema](https://schema.laboperator.com/schemas/definitions/field_schema/timer) "
                     }
                 },
                 "examples": [
@@ -1714,7 +1719,7 @@
                         "showResetButton": true
                     }
                 ],
-                "markdownDescription": "Defines a field of type `timer`. Timers are used to measure time or execute time-controlled actions within a Workflow Run.\n\nTimers have two possible modes of operation: countdown and stopwatch.\n\nIn **countdown** mode, the timer will run for a specified duration, and fire a `on_timer_complete` Trigger upon completion.\nIn **stopwatch** mode, the timer measures time until it is stopped, either manually or through a Behavior.\n\nTimer fields can be assigned to individual substeps by passing the field identifier to the `timer` property.\n\n\nSee more: [Timer Schema](https://schema.laboperator.com/schemas/definitions/field_schema/timer) "
+                "markdownDescription": "Defines a field of type `timer` to measure time or execute time-controlled actions.\n\nTimers have two possible modes of operation, countdown and stopwatch. In countdown mode, the timer will run for a specified duration and fire a [Timer Complete trigger](https://schema.laboperator.com/schemas/definitions/workflow_template/trigger_objects/timerComplete/) upon completion. In _stopwatch_ mode, the timer measures time until it is stopped, either manually or through an [action](/schemas/definitions/workflow_template/actions/).\n\n\nSee more: [Timer Schema](https://schema.laboperator.com/schemas/definitions/field_schema/timer) "
             }
         },
         "flow": {

--- a/src/schemata/definitions/field_schema/timer.yml
+++ b/src/schemata/definitions/field_schema/timer.yml
@@ -46,15 +46,3 @@ properties:
     description: |
       A flag indicating whether to skip automatically creating behaviors to
       handle buttons on the timer.
-  editable:
-    type: boolean
-    default: false
-    description: |
-      A flag indicating whether the duration can be manually adjusted at
-      runtime.
-  playSound:
-    type: boolean
-    default: false
-    description: |
-      A flag indicating whether the timer should trigger a sound when
-      going off. The sound can always be toggled at runtime.

--- a/src/schemata/definitions/field_schema/timer.yml
+++ b/src/schemata/definitions/field_schema/timer.yml
@@ -46,3 +46,11 @@ properties:
     description: |
       A flag indicating whether to skip automatically creating behaviors to
       handle buttons on the timer.
+examples:
+  - type: timer
+    defaultDuration: 120 seconds
+    showButtons: true
+  - type: timer
+    skipBehaviors: true
+    showStartButton: true
+    showResetButton: true

--- a/src/schemata/definitions/field_schema/timer.yml
+++ b/src/schemata/definitions/field_schema/timer.yml
@@ -1,31 +1,45 @@
 ---
 type: object
 description: |
-  Defines a field of type `timer`.
+  Defines a field of type `timer`. Timers are used to measure time or execute time-controlled actions within a Workflow Run.
+
+  Timers have two possible modes of operation: countdown and stopwatch.
+  
+  In **countdown** mode, the timer will run for a specified duration, and fire a `on_timer_complete` Trigger upon completion.
+  In **stopwatch** mode, the timer measures time until it is stopped, either manually or through a Behavior.
+  
+  Timer fields can be assigned to individual substeps by passing the field identifier to the `timer` property.
 required: [type]
 properties:
   type:
     type: string
     enum: [timer]
   defaultDuration:
-    description: A fixed duration.
+    description: |
+      The default value set on the timer upon starting the workflow. If this is defined, the timer will run in countdown mode, unless the value is reset during workflow execution.
+
+      The initial value of the timer can also be set using the `defaultValue` property. If both are defined, `defaultValue` will overwrite the value set in `defaultDuration`.
     $ref: '#/definitions/duration'
   showButtons:
     type: boolean
-    default: true
-    description: A flag indicating whether to show the buttons.
+    default: false
+    description: |
+      A flag indicating whether to show all the buttons to control the timer. When this property is set to `true`, it will take precedence over the flags for individual buttons.
   showStartButton:
     type: boolean
-    default: true
-    description: A flag indicating whether to show the start button.
-  showPauseButton:
+    default: false
+    description: |
+      A flag indicating whether to show the start button.
+  showStopButton:
     type: boolean
-    default: true
-    description: A flag indicating whether to show the pause button.
-  showCancelButton:
+    default: false
+    description: |
+      A flag indicating whether to show the stop button.
+  showResetButton:
     type: boolean
-    default: true
-    description: A flag indicating whether to show the cancel button.
+    default: false
+    description: |
+      A flag indicating whether to show the reset button.
   skipBehaviors:
     type: boolean
     default: false

--- a/src/schemata/definitions/field_schema/timer.yml
+++ b/src/schemata/definitions/field_schema/timer.yml
@@ -1,30 +1,27 @@
 ---
 type: object
 description: |
-  Defines a field of type `timer`. Timers are used to measure time or execute time-controlled actions within a Workflow Run.
+  Defines a field of type `timer` to measure time or execute time-controlled actions.
 
-  Timers have two possible modes of operation: countdown and stopwatch.
-  
-  In **countdown** mode, the timer will run for a specified duration, and fire a `on_timer_complete` Trigger upon completion.
-  In **stopwatch** mode, the timer measures time until it is stopped, either manually or through a Behavior.
-  
-  Timer fields can be assigned to individual substeps by passing the field identifier to the `timer` property.
+  Timers have two possible modes of operation, countdown and stopwatch. In countdown mode, the timer will run for a specified duration and fire a [Timer Complete trigger](/schemas/definitions/workflow_template/trigger_objects/timerComplete/) upon completion. In _stopwatch_ mode, the timer measures time until it is stopped, either manually or through an [action](/schemas/definitions/workflow_template/actions/).
 required: [type]
 properties:
   type:
     type: string
     enum: [timer]
   defaultDuration:
-    description: |
-      The default value set on the timer upon starting the workflow. If this is defined, the timer will run in countdown mode, unless the value is reset during workflow execution.
-
-      The initial value of the timer can also be set using the `defaultValue` property. If both are defined, `defaultValue` will overwrite the value set in `defaultDuration`.
     $ref: '#/definitions/duration'
+    description: |
+      The default value of the timer. If set to a non-zero value, the timer will run in countdown mode. If no duration is defined or it is set to _"0:00"_, the timer will run in stopwatch mode. Note that also defining `defaultValue` will overwrite this setting.
+    examples:
+      - 90
+      - 1 mins 30 sec
+      - 1:30
   showButtons:
     type: boolean
     default: false
     description: |
-      A flag indicating whether to show all the buttons to control the timer. When this property is set to `true`, it will take precedence over the flags for individual buttons.
+      A flag indicating whether to show all timer control buttons. Use this setting to conveniently remove all buttons in case of the timer being controlled entirely by [actions](/schemas/definitions/workflow_template/actions/). This setting take precedence over the settings for the individual buttons.
   showStartButton:
     type: boolean
     default: false
@@ -45,7 +42,7 @@ properties:
     default: false
     description: |
       A flag indicating whether to skip automatically creating behaviors to
-      handle buttons on the timer.
+      handle the control button, e.g. starting the countdown.
 examples:
   - type: timer
     defaultDuration: 120 seconds

--- a/src/workflow_step_template_schema.json
+++ b/src/workflow_step_template_schema.json
@@ -1629,7 +1629,7 @@
       },
       "timer": {
         "type": "object",
-        "description": "Defines a field of type `timer`. Timers are used to measure time or execute time-controlled actions within a Workflow Run.\n\nTimers have two possible modes of operation: countdown and stopwatch.\n\nIn **countdown** mode, the timer will run for a specified duration, and fire a `on_timer_complete` Trigger upon completion.\nIn **stopwatch** mode, the timer measures time until it is stopped, either manually or through a Behavior.\n\nTimer fields can be assigned to individual substeps by passing the field identifier to the `timer` property.\n",
+        "description": "Defines a field of type `timer` to measure time or execute time-controlled actions.\n\nTimers have two possible modes of operation, countdown and stopwatch. In countdown mode, the timer will run for a specified duration and fire a [Timer Complete trigger](/schemas/definitions/workflow_template/trigger_objects/timerComplete/) upon completion. In _stopwatch_ mode, the timer measures time until it is stopped, either manually or through an [action](/schemas/definitions/workflow_template/actions/).\n",
         "required": [
           "type"
         ],
@@ -1641,15 +1641,20 @@
             ]
           },
           "defaultDuration": {
-            "description": "The default value set on the timer upon starting the workflow. If this is defined, the timer will run in countdown mode, unless the value is reset during workflow execution.\n\nThe initial value of the timer can also be set using the `defaultValue` property. If both are defined, `defaultValue` will overwrite the value set in `defaultDuration`.\n",
             "$ref": "#/definitions/duration",
-            "markdownDescription": "The default value set on the timer upon starting the workflow. If this is defined, the timer will run in countdown mode, unless the value is reset during workflow execution.\n\nThe initial value of the timer can also be set using the `defaultValue` property. If both are defined, `defaultValue` will overwrite the value set in `defaultDuration`.\n\n\nSee more: [Timer Schema](https://schema.laboperator.com/schemas/definitions/field_schema/timer) "
+            "description": "The default value of the timer. If set to a non-zero value, the timer will run in countdown mode. If no duration is defined or it is set to _\"0:00\"_, the timer will run in stopwatch mode. Note that also defining `defaultValue` will overwrite this setting.\n",
+            "examples": [
+              90,
+              "1 mins 30 sec",
+              "1:30"
+            ],
+            "markdownDescription": "The default value of the timer. If set to a non-zero value, the timer will run in countdown mode. If no duration is defined or it is set to _\"0:00\"_, the timer will run in stopwatch mode. Note that also defining `defaultValue` will overwrite this setting.\n\n\nSee more: [Timer Schema](https://schema.laboperator.com/schemas/definitions/field_schema/timer) "
           },
           "showButtons": {
             "type": "boolean",
             "default": false,
-            "description": "A flag indicating whether to show all the buttons to control the timer. When this property is set to `true`, it will take precedence over the flags for individual buttons.\n",
-            "markdownDescription": "A flag indicating whether to show all the buttons to control the timer. When this property is set to `true`, it will take precedence over the flags for individual buttons.\n\n\nSee more: [Timer Schema](https://schema.laboperator.com/schemas/definitions/field_schema/timer) "
+            "description": "A flag indicating whether to show all timer control buttons. Use this setting to conveniently remove all buttons in case of the timer being controlled entirely by [actions](/schemas/definitions/workflow_template/actions/). This setting take precedence over the settings for the individual buttons.\n",
+            "markdownDescription": "A flag indicating whether to show all timer control buttons. Use this setting to conveniently remove all buttons in case of the timer being controlled entirely by [actions](https://schema.laboperator.com/schemas/definitions/workflow_template/actions/). This setting take precedence over the settings for the individual buttons.\n\n\nSee more: [Timer Schema](https://schema.laboperator.com/schemas/definitions/field_schema/timer) "
           },
           "showStartButton": {
             "type": "boolean",
@@ -1672,8 +1677,8 @@
           "skipBehaviors": {
             "type": "boolean",
             "default": false,
-            "description": "A flag indicating whether to skip automatically creating behaviors to\nhandle buttons on the timer.\n",
-            "markdownDescription": "A flag indicating whether to skip automatically creating behaviors to\nhandle buttons on the timer.\n\n\nSee more: [Timer Schema](https://schema.laboperator.com/schemas/definitions/field_schema/timer) "
+            "description": "A flag indicating whether to skip automatically creating behaviors to\nhandle the control button, e.g. starting the countdown.\n",
+            "markdownDescription": "A flag indicating whether to skip automatically creating behaviors to\nhandle the control button, e.g. starting the countdown.\n\n\nSee more: [Timer Schema](https://schema.laboperator.com/schemas/definitions/field_schema/timer) "
           }
         },
         "examples": [
@@ -1689,7 +1694,7 @@
             "showResetButton": true
           }
         ],
-        "markdownDescription": "Defines a field of type `timer`. Timers are used to measure time or execute time-controlled actions within a Workflow Run.\n\nTimers have two possible modes of operation: countdown and stopwatch.\n\nIn **countdown** mode, the timer will run for a specified duration, and fire a `on_timer_complete` Trigger upon completion.\nIn **stopwatch** mode, the timer measures time until it is stopped, either manually or through a Behavior.\n\nTimer fields can be assigned to individual substeps by passing the field identifier to the `timer` property.\n\n\nSee more: [Timer Schema](https://schema.laboperator.com/schemas/definitions/field_schema/timer) "
+        "markdownDescription": "Defines a field of type `timer` to measure time or execute time-controlled actions.\n\nTimers have two possible modes of operation, countdown and stopwatch. In countdown mode, the timer will run for a specified duration and fire a [Timer Complete trigger](https://schema.laboperator.com/schemas/definitions/workflow_template/trigger_objects/timerComplete/) upon completion. In _stopwatch_ mode, the timer measures time until it is stopped, either manually or through an [action](/schemas/definitions/workflow_template/actions/).\n\n\nSee more: [Timer Schema](https://schema.laboperator.com/schemas/definitions/field_schema/timer) "
       }
     },
     "flow": {

--- a/src/workflow_step_template_schema.json
+++ b/src/workflow_step_template_schema.json
@@ -1629,7 +1629,7 @@
       },
       "timer": {
         "type": "object",
-        "description": "Defines a field of type `timer`.\n",
+        "description": "Defines a field of type `timer`. Timers are used to measure time or execute time-controlled actions within a Workflow Run.\n\nTimers have two possible modes of operation: countdown and stopwatch.\n\nIn **countdown** mode, the timer will run for a specified duration, and fire a `on_timer_complete` Trigger upon completion.\nIn **stopwatch** mode, the timer measures time until it is stopped, either manually or through a Behavior.\n\nTimer fields can be assigned to individual substeps by passing the field identifier to the `timer` property.\n",
         "required": [
           "type"
         ],
@@ -1641,33 +1641,33 @@
             ]
           },
           "defaultDuration": {
-            "description": "A fixed duration.",
+            "description": "The default value set on the timer upon starting the workflow. If this is defined, the timer will run in countdown mode, unless the value is reset during workflow execution.\n\nThe initial value of the timer can also be set using the `defaultValue` property. If both are defined, `defaultValue` will overwrite the value set in `defaultDuration`.\n",
             "$ref": "#/definitions/duration",
-            "markdownDescription": "A fixed duration.\n\nSee more: [Timer Schema](https://schema.laboperator.com/schemas/definitions/field_schema/timer) "
+            "markdownDescription": "The default value set on the timer upon starting the workflow. If this is defined, the timer will run in countdown mode, unless the value is reset during workflow execution.\n\nThe initial value of the timer can also be set using the `defaultValue` property. If both are defined, `defaultValue` will overwrite the value set in `defaultDuration`.\n\n\nSee more: [Timer Schema](https://schema.laboperator.com/schemas/definitions/field_schema/timer) "
           },
           "showButtons": {
             "type": "boolean",
-            "default": true,
-            "description": "A flag indicating whether to show the buttons.",
-            "markdownDescription": "A flag indicating whether to show the buttons.\n\nSee more: [Timer Schema](https://schema.laboperator.com/schemas/definitions/field_schema/timer) "
+            "default": false,
+            "description": "A flag indicating whether to show all the buttons to control the timer. When this property is set to `true`, it will take precedence over the flags for individual buttons.\n",
+            "markdownDescription": "A flag indicating whether to show all the buttons to control the timer. When this property is set to `true`, it will take precedence over the flags for individual buttons.\n\n\nSee more: [Timer Schema](https://schema.laboperator.com/schemas/definitions/field_schema/timer) "
           },
           "showStartButton": {
             "type": "boolean",
-            "default": true,
-            "description": "A flag indicating whether to show the start button.",
-            "markdownDescription": "A flag indicating whether to show the start button.\n\nSee more: [Timer Schema](https://schema.laboperator.com/schemas/definitions/field_schema/timer) "
+            "default": false,
+            "description": "A flag indicating whether to show the start button.\n",
+            "markdownDescription": "A flag indicating whether to show the start button.\n\n\nSee more: [Timer Schema](https://schema.laboperator.com/schemas/definitions/field_schema/timer) "
           },
-          "showPauseButton": {
+          "showStopButton": {
             "type": "boolean",
-            "default": true,
-            "description": "A flag indicating whether to show the pause button.",
-            "markdownDescription": "A flag indicating whether to show the pause button.\n\nSee more: [Timer Schema](https://schema.laboperator.com/schemas/definitions/field_schema/timer) "
+            "default": false,
+            "description": "A flag indicating whether to show the stop button.\n",
+            "markdownDescription": "A flag indicating whether to show the stop button.\n\n\nSee more: [Timer Schema](https://schema.laboperator.com/schemas/definitions/field_schema/timer) "
           },
-          "showCancelButton": {
+          "showResetButton": {
             "type": "boolean",
-            "default": true,
-            "description": "A flag indicating whether to show the cancel button.",
-            "markdownDescription": "A flag indicating whether to show the cancel button.\n\nSee more: [Timer Schema](https://schema.laboperator.com/schemas/definitions/field_schema/timer) "
+            "default": false,
+            "description": "A flag indicating whether to show the reset button.\n",
+            "markdownDescription": "A flag indicating whether to show the reset button.\n\n\nSee more: [Timer Schema](https://schema.laboperator.com/schemas/definitions/field_schema/timer) "
           },
           "skipBehaviors": {
             "type": "boolean",
@@ -1688,7 +1688,7 @@
             "markdownDescription": "A flag indicating whether the timer should trigger a sound when\ngoing off. The sound can always be toggled at runtime.\n\n\nSee more: [Timer Schema](https://schema.laboperator.com/schemas/definitions/field_schema/timer) "
           }
         },
-        "markdownDescription": "Defines a field of type `timer`.\n\n\nSee more: [Timer Schema](https://schema.laboperator.com/schemas/definitions/field_schema/timer) "
+        "markdownDescription": "Defines a field of type `timer`. Timers are used to measure time or execute time-controlled actions within a Workflow Run.\n\nTimers have two possible modes of operation: countdown and stopwatch.\n\nIn **countdown** mode, the timer will run for a specified duration, and fire a `on_timer_complete` Trigger upon completion.\nIn **stopwatch** mode, the timer measures time until it is stopped, either manually or through a Behavior.\n\nTimer fields can be assigned to individual substeps by passing the field identifier to the `timer` property.\n\n\nSee more: [Timer Schema](https://schema.laboperator.com/schemas/definitions/field_schema/timer) "
       }
     },
     "flow": {

--- a/src/workflow_step_template_schema.json
+++ b/src/workflow_step_template_schema.json
@@ -1674,18 +1674,6 @@
             "default": false,
             "description": "A flag indicating whether to skip automatically creating behaviors to\nhandle buttons on the timer.\n",
             "markdownDescription": "A flag indicating whether to skip automatically creating behaviors to\nhandle buttons on the timer.\n\n\nSee more: [Timer Schema](https://schema.laboperator.com/schemas/definitions/field_schema/timer) "
-          },
-          "editable": {
-            "type": "boolean",
-            "default": false,
-            "description": "A flag indicating whether the duration can be manually adjusted at\nruntime.\n",
-            "markdownDescription": "A flag indicating whether the duration can be manually adjusted at\nruntime.\n\n\nSee more: [Timer Schema](https://schema.laboperator.com/schemas/definitions/field_schema/timer) "
-          },
-          "playSound": {
-            "type": "boolean",
-            "default": false,
-            "description": "A flag indicating whether the timer should trigger a sound when\ngoing off. The sound can always be toggled at runtime.\n",
-            "markdownDescription": "A flag indicating whether the timer should trigger a sound when\ngoing off. The sound can always be toggled at runtime.\n\n\nSee more: [Timer Schema](https://schema.laboperator.com/schemas/definitions/field_schema/timer) "
           }
         },
         "markdownDescription": "Defines a field of type `timer`. Timers are used to measure time or execute time-controlled actions within a Workflow Run.\n\nTimers have two possible modes of operation: countdown and stopwatch.\n\nIn **countdown** mode, the timer will run for a specified duration, and fire a `on_timer_complete` Trigger upon completion.\nIn **stopwatch** mode, the timer measures time until it is stopped, either manually or through a Behavior.\n\nTimer fields can be assigned to individual substeps by passing the field identifier to the `timer` property.\n\n\nSee more: [Timer Schema](https://schema.laboperator.com/schemas/definitions/field_schema/timer) "

--- a/src/workflow_step_template_schema.json
+++ b/src/workflow_step_template_schema.json
@@ -1676,6 +1676,19 @@
             "markdownDescription": "A flag indicating whether to skip automatically creating behaviors to\nhandle buttons on the timer.\n\n\nSee more: [Timer Schema](https://schema.laboperator.com/schemas/definitions/field_schema/timer) "
           }
         },
+        "examples": [
+          {
+            "type": "timer",
+            "defaultDuration": "120 seconds",
+            "showButtons": true
+          },
+          {
+            "type": "timer",
+            "skipBehaviors": true,
+            "showStartButton": true,
+            "showResetButton": true
+          }
+        ],
         "markdownDescription": "Defines a field of type `timer`. Timers are used to measure time or execute time-controlled actions within a Workflow Run.\n\nTimers have two possible modes of operation: countdown and stopwatch.\n\nIn **countdown** mode, the timer will run for a specified duration, and fire a `on_timer_complete` Trigger upon completion.\nIn **stopwatch** mode, the timer measures time until it is stopped, either manually or through a Behavior.\n\nTimer fields can be assigned to individual substeps by passing the field identifier to the `timer` property.\n\n\nSee more: [Timer Schema](https://schema.laboperator.com/schemas/definitions/field_schema/timer) "
       }
     },

--- a/src/workflow_template_schema.json
+++ b/src/workflow_template_schema.json
@@ -1699,18 +1699,6 @@
             "default": false,
             "description": "A flag indicating whether to skip automatically creating behaviors to\nhandle buttons on the timer.\n",
             "markdownDescription": "A flag indicating whether to skip automatically creating behaviors to\nhandle buttons on the timer.\n\n\nSee more: [Timer Schema](https://schema.laboperator.com/schemas/definitions/field_schema/timer) "
-          },
-          "editable": {
-            "type": "boolean",
-            "default": false,
-            "description": "A flag indicating whether the duration can be manually adjusted at\nruntime.\n",
-            "markdownDescription": "A flag indicating whether the duration can be manually adjusted at\nruntime.\n\n\nSee more: [Timer Schema](https://schema.laboperator.com/schemas/definitions/field_schema/timer) "
-          },
-          "playSound": {
-            "type": "boolean",
-            "default": false,
-            "description": "A flag indicating whether the timer should trigger a sound when\ngoing off. The sound can always be toggled at runtime.\n",
-            "markdownDescription": "A flag indicating whether the timer should trigger a sound when\ngoing off. The sound can always be toggled at runtime.\n\n\nSee more: [Timer Schema](https://schema.laboperator.com/schemas/definitions/field_schema/timer) "
           }
         },
         "markdownDescription": "Defines a field of type `timer`. Timers are used to measure time or execute time-controlled actions within a Workflow Run.\n\nTimers have two possible modes of operation: countdown and stopwatch.\n\nIn **countdown** mode, the timer will run for a specified duration, and fire a `on_timer_complete` Trigger upon completion.\nIn **stopwatch** mode, the timer measures time until it is stopped, either manually or through a Behavior.\n\nTimer fields can be assigned to individual substeps by passing the field identifier to the `timer` property.\n\n\nSee more: [Timer Schema](https://schema.laboperator.com/schemas/definitions/field_schema/timer) "

--- a/src/workflow_template_schema.json
+++ b/src/workflow_template_schema.json
@@ -1654,7 +1654,7 @@
       },
       "timer": {
         "type": "object",
-        "description": "Defines a field of type `timer`. Timers are used to measure time or execute time-controlled actions within a Workflow Run.\n\nTimers have two possible modes of operation: countdown and stopwatch.\n\nIn **countdown** mode, the timer will run for a specified duration, and fire a `on_timer_complete` Trigger upon completion.\nIn **stopwatch** mode, the timer measures time until it is stopped, either manually or through a Behavior.\n\nTimer fields can be assigned to individual substeps by passing the field identifier to the `timer` property.\n",
+        "description": "Defines a field of type `timer` to measure time or execute time-controlled actions.\n\nTimers have two possible modes of operation, countdown and stopwatch. In countdown mode, the timer will run for a specified duration and fire a [Timer Complete trigger](/schemas/definitions/workflow_template/trigger_objects/timerComplete/) upon completion. In _stopwatch_ mode, the timer measures time until it is stopped, either manually or through an [action](/schemas/definitions/workflow_template/actions/).\n",
         "required": [
           "type"
         ],
@@ -1666,15 +1666,20 @@
             ]
           },
           "defaultDuration": {
-            "description": "The default value set on the timer upon starting the workflow. If this is defined, the timer will run in countdown mode, unless the value is reset during workflow execution.\n\nThe initial value of the timer can also be set using the `defaultValue` property. If both are defined, `defaultValue` will overwrite the value set in `defaultDuration`.\n",
             "$ref": "#/definitions/duration",
-            "markdownDescription": "The default value set on the timer upon starting the workflow. If this is defined, the timer will run in countdown mode, unless the value is reset during workflow execution.\n\nThe initial value of the timer can also be set using the `defaultValue` property. If both are defined, `defaultValue` will overwrite the value set in `defaultDuration`.\n\n\nSee more: [Timer Schema](https://schema.laboperator.com/schemas/definitions/field_schema/timer) "
+            "description": "The default value of the timer. If set to a non-zero value, the timer will run in countdown mode. If no duration is defined or it is set to _\"0:00\"_, the timer will run in stopwatch mode. Note that also defining `defaultValue` will overwrite this setting.\n",
+            "examples": [
+              90,
+              "1 mins 30 sec",
+              "1:30"
+            ],
+            "markdownDescription": "The default value of the timer. If set to a non-zero value, the timer will run in countdown mode. If no duration is defined or it is set to _\"0:00\"_, the timer will run in stopwatch mode. Note that also defining `defaultValue` will overwrite this setting.\n\n\nSee more: [Timer Schema](https://schema.laboperator.com/schemas/definitions/field_schema/timer) "
           },
           "showButtons": {
             "type": "boolean",
             "default": false,
-            "description": "A flag indicating whether to show all the buttons to control the timer. When this property is set to `true`, it will take precedence over the flags for individual buttons.\n",
-            "markdownDescription": "A flag indicating whether to show all the buttons to control the timer. When this property is set to `true`, it will take precedence over the flags for individual buttons.\n\n\nSee more: [Timer Schema](https://schema.laboperator.com/schemas/definitions/field_schema/timer) "
+            "description": "A flag indicating whether to show all timer control buttons. Use this setting to conveniently remove all buttons in case of the timer being controlled entirely by [actions](/schemas/definitions/workflow_template/actions/). This setting take precedence over the settings for the individual buttons.\n",
+            "markdownDescription": "A flag indicating whether to show all timer control buttons. Use this setting to conveniently remove all buttons in case of the timer being controlled entirely by [actions](https://schema.laboperator.com/schemas/definitions/workflow_template/actions/). This setting take precedence over the settings for the individual buttons.\n\n\nSee more: [Timer Schema](https://schema.laboperator.com/schemas/definitions/field_schema/timer) "
           },
           "showStartButton": {
             "type": "boolean",
@@ -1697,8 +1702,8 @@
           "skipBehaviors": {
             "type": "boolean",
             "default": false,
-            "description": "A flag indicating whether to skip automatically creating behaviors to\nhandle buttons on the timer.\n",
-            "markdownDescription": "A flag indicating whether to skip automatically creating behaviors to\nhandle buttons on the timer.\n\n\nSee more: [Timer Schema](https://schema.laboperator.com/schemas/definitions/field_schema/timer) "
+            "description": "A flag indicating whether to skip automatically creating behaviors to\nhandle the control button, e.g. starting the countdown.\n",
+            "markdownDescription": "A flag indicating whether to skip automatically creating behaviors to\nhandle the control button, e.g. starting the countdown.\n\n\nSee more: [Timer Schema](https://schema.laboperator.com/schemas/definitions/field_schema/timer) "
           }
         },
         "examples": [
@@ -1714,7 +1719,7 @@
             "showResetButton": true
           }
         ],
-        "markdownDescription": "Defines a field of type `timer`. Timers are used to measure time or execute time-controlled actions within a Workflow Run.\n\nTimers have two possible modes of operation: countdown and stopwatch.\n\nIn **countdown** mode, the timer will run for a specified duration, and fire a `on_timer_complete` Trigger upon completion.\nIn **stopwatch** mode, the timer measures time until it is stopped, either manually or through a Behavior.\n\nTimer fields can be assigned to individual substeps by passing the field identifier to the `timer` property.\n\n\nSee more: [Timer Schema](https://schema.laboperator.com/schemas/definitions/field_schema/timer) "
+        "markdownDescription": "Defines a field of type `timer` to measure time or execute time-controlled actions.\n\nTimers have two possible modes of operation, countdown and stopwatch. In countdown mode, the timer will run for a specified duration and fire a [Timer Complete trigger](https://schema.laboperator.com/schemas/definitions/workflow_template/trigger_objects/timerComplete/) upon completion. In _stopwatch_ mode, the timer measures time until it is stopped, either manually or through an [action](/schemas/definitions/workflow_template/actions/).\n\n\nSee more: [Timer Schema](https://schema.laboperator.com/schemas/definitions/field_schema/timer) "
       }
     },
     "flow": {

--- a/src/workflow_template_schema.json
+++ b/src/workflow_template_schema.json
@@ -1654,7 +1654,7 @@
       },
       "timer": {
         "type": "object",
-        "description": "Defines a field of type `timer`.\n",
+        "description": "Defines a field of type `timer`. Timers are used to measure time or execute time-controlled actions within a Workflow Run.\n\nTimers have two possible modes of operation: countdown and stopwatch.\n\nIn **countdown** mode, the timer will run for a specified duration, and fire a `on_timer_complete` Trigger upon completion.\nIn **stopwatch** mode, the timer measures time until it is stopped, either manually or through a Behavior.\n\nTimer fields can be assigned to individual substeps by passing the field identifier to the `timer` property.\n",
         "required": [
           "type"
         ],
@@ -1666,33 +1666,33 @@
             ]
           },
           "defaultDuration": {
-            "description": "A fixed duration.",
+            "description": "The default value set on the timer upon starting the workflow. If this is defined, the timer will run in countdown mode, unless the value is reset during workflow execution.\n\nThe initial value of the timer can also be set using the `defaultValue` property. If both are defined, `defaultValue` will overwrite the value set in `defaultDuration`.\n",
             "$ref": "#/definitions/duration",
-            "markdownDescription": "A fixed duration.\n\nSee more: [Timer Schema](https://schema.laboperator.com/schemas/definitions/field_schema/timer) "
+            "markdownDescription": "The default value set on the timer upon starting the workflow. If this is defined, the timer will run in countdown mode, unless the value is reset during workflow execution.\n\nThe initial value of the timer can also be set using the `defaultValue` property. If both are defined, `defaultValue` will overwrite the value set in `defaultDuration`.\n\n\nSee more: [Timer Schema](https://schema.laboperator.com/schemas/definitions/field_schema/timer) "
           },
           "showButtons": {
             "type": "boolean",
-            "default": true,
-            "description": "A flag indicating whether to show the buttons.",
-            "markdownDescription": "A flag indicating whether to show the buttons.\n\nSee more: [Timer Schema](https://schema.laboperator.com/schemas/definitions/field_schema/timer) "
+            "default": false,
+            "description": "A flag indicating whether to show all the buttons to control the timer. When this property is set to `true`, it will take precedence over the flags for individual buttons.\n",
+            "markdownDescription": "A flag indicating whether to show all the buttons to control the timer. When this property is set to `true`, it will take precedence over the flags for individual buttons.\n\n\nSee more: [Timer Schema](https://schema.laboperator.com/schemas/definitions/field_schema/timer) "
           },
           "showStartButton": {
             "type": "boolean",
-            "default": true,
-            "description": "A flag indicating whether to show the start button.",
-            "markdownDescription": "A flag indicating whether to show the start button.\n\nSee more: [Timer Schema](https://schema.laboperator.com/schemas/definitions/field_schema/timer) "
+            "default": false,
+            "description": "A flag indicating whether to show the start button.\n",
+            "markdownDescription": "A flag indicating whether to show the start button.\n\n\nSee more: [Timer Schema](https://schema.laboperator.com/schemas/definitions/field_schema/timer) "
           },
-          "showPauseButton": {
+          "showStopButton": {
             "type": "boolean",
-            "default": true,
-            "description": "A flag indicating whether to show the pause button.",
-            "markdownDescription": "A flag indicating whether to show the pause button.\n\nSee more: [Timer Schema](https://schema.laboperator.com/schemas/definitions/field_schema/timer) "
+            "default": false,
+            "description": "A flag indicating whether to show the stop button.\n",
+            "markdownDescription": "A flag indicating whether to show the stop button.\n\n\nSee more: [Timer Schema](https://schema.laboperator.com/schemas/definitions/field_schema/timer) "
           },
-          "showCancelButton": {
+          "showResetButton": {
             "type": "boolean",
-            "default": true,
-            "description": "A flag indicating whether to show the cancel button.",
-            "markdownDescription": "A flag indicating whether to show the cancel button.\n\nSee more: [Timer Schema](https://schema.laboperator.com/schemas/definitions/field_schema/timer) "
+            "default": false,
+            "description": "A flag indicating whether to show the reset button.\n",
+            "markdownDescription": "A flag indicating whether to show the reset button.\n\n\nSee more: [Timer Schema](https://schema.laboperator.com/schemas/definitions/field_schema/timer) "
           },
           "skipBehaviors": {
             "type": "boolean",
@@ -1713,7 +1713,7 @@
             "markdownDescription": "A flag indicating whether the timer should trigger a sound when\ngoing off. The sound can always be toggled at runtime.\n\n\nSee more: [Timer Schema](https://schema.laboperator.com/schemas/definitions/field_schema/timer) "
           }
         },
-        "markdownDescription": "Defines a field of type `timer`.\n\n\nSee more: [Timer Schema](https://schema.laboperator.com/schemas/definitions/field_schema/timer) "
+        "markdownDescription": "Defines a field of type `timer`. Timers are used to measure time or execute time-controlled actions within a Workflow Run.\n\nTimers have two possible modes of operation: countdown and stopwatch.\n\nIn **countdown** mode, the timer will run for a specified duration, and fire a `on_timer_complete` Trigger upon completion.\nIn **stopwatch** mode, the timer measures time until it is stopped, either manually or through a Behavior.\n\nTimer fields can be assigned to individual substeps by passing the field identifier to the `timer` property.\n\n\nSee more: [Timer Schema](https://schema.laboperator.com/schemas/definitions/field_schema/timer) "
       }
     },
     "flow": {

--- a/src/workflow_template_schema.json
+++ b/src/workflow_template_schema.json
@@ -1701,6 +1701,19 @@
             "markdownDescription": "A flag indicating whether to skip automatically creating behaviors to\nhandle buttons on the timer.\n\n\nSee more: [Timer Schema](https://schema.laboperator.com/schemas/definitions/field_schema/timer) "
           }
         },
+        "examples": [
+          {
+            "type": "timer",
+            "defaultDuration": "120 seconds",
+            "showButtons": true
+          },
+          {
+            "type": "timer",
+            "skipBehaviors": true,
+            "showStartButton": true,
+            "showResetButton": true
+          }
+        ],
         "markdownDescription": "Defines a field of type `timer`. Timers are used to measure time or execute time-controlled actions within a Workflow Run.\n\nTimers have two possible modes of operation: countdown and stopwatch.\n\nIn **countdown** mode, the timer will run for a specified duration, and fire a `on_timer_complete` Trigger upon completion.\nIn **stopwatch** mode, the timer measures time until it is stopped, either manually or through a Behavior.\n\nTimer fields can be assigned to individual substeps by passing the field identifier to the `timer` property.\n\n\nSee more: [Timer Schema](https://schema.laboperator.com/schemas/definitions/field_schema/timer) "
       }
     },


### PR DESCRIPTION
The current schema definition is incomplete and describes properties that are not used, while the ones which are actually used are not defined in the schema.

These changes were introduced in a [very old PR](https://github.com/labforward/laboperator-server/pull/939), where the schema was created based on a first implementation. That implementation was later changed within the same PR, but the schema remained the same.

List of amended inconsistencies:
- removed `showCancelButton` and `showPauseButton`, both of which are outdated and have no bearing on the functionality
- added `showStopButton` and `showResetButton` properties which are the ones actually used within the code
- changed the `default` value for the `show...` flags to `false`, as the buttons are not displayed if none of the flags are set to `true`.
- `showButtons` takes precedence over any of the flags for individual buttons (if it's set to `true`, all of the buttons would still show if their flags were set to `false`). This has been reflected in the description.

Other changes:
- Added line breaks for descriptions to ensure proper styling
- Added information on modes of operation of a timer
- Added information about how `defaultDuration` interacts with `defaultValue`, if both are defined.