### PR TITLE
[chore] Add string widget default

### DIFF
--- a/dist/workflow_step_template_schema.json
+++ b/dist/workflow_step_template_schema.json
@@ -429,11 +429,11 @@
                             "enum": [
                                 "checkbox",
                                 "switch",
-                                "textarea",
-                                "input"
+                                "text",
+                                "textarea"
                             ],
-                            "description": "A flag indicating the widget variant for fields of type `string` or `boolean`. All other field types ignore this setting.\nBoolean fields can be displayed as either a checkbox or a switch to toggle between a binary state. The default appearance is a checkbox. Fields of type `string` can be configured as a multi-line textarea element. Their default appearance is a single-line input.\n",
-                            "markdownDescription": "A flag indicating the widget variant for fields of type `string` or `boolean`. All other field types ignore this setting.\nBoolean fields can be displayed as either a checkbox or a switch to toggle between a binary state. The default appearance is a checkbox. Fields of type `string` can be configured as a multi-line textarea element. Their default appearance is a single-line input.\n\n\nSee more: [Field Schema](https://schema.laboperator.com/schemas/definitions/field) "
+                            "description": "A flag indicating the widget variant for fields of type `string` or `boolean`. All other field types ignore this setting.\nBoolean fields can be displayed as either a checkbox or a switch to toggle between a binary state. The default appearance is a checkbox. Fields of type `string` can be configured as a multi-line textarea element. Their default appearance is a single-line text input.\n",
+                            "markdownDescription": "A flag indicating the widget variant for fields of type `string` or `boolean`. All other field types ignore this setting.\nBoolean fields can be displayed as either a checkbox or a switch to toggle between a binary state. The default appearance is a checkbox. Fields of type `string` can be configured as a multi-line textarea element. Their default appearance is a single-line text input.\n\n\nSee more: [Field Schema](https://schema.laboperator.com/schemas/definitions/field) "
                         },
                         "ui:options": {
                             "type": "object",

--- a/dist/workflow_step_template_schema.json
+++ b/dist/workflow_step_template_schema.json
@@ -429,10 +429,11 @@
                             "enum": [
                                 "checkbox",
                                 "switch",
-                                "textarea"
+                                "textarea",
+                                "input"
                             ],
-                            "description": "A flag indicating the widget variant for fields of type `string` or `boolean`.\n\nBoolean fields can be displayed as either a checkbox or a switch to toggle between a binary state. The default appearance is a checkbox.\nFields of type `string` can be configured as a textarea element, which allows for multi-line text. The default appearance is a single-line input.\n\nIf a field type does not support a certain `ui:widget`, the setting is ignored.\n",
-                            "markdownDescription": "A flag indicating the widget variant for fields of type `string` or `boolean`.\n\nBoolean fields can be displayed as either a checkbox or a switch to toggle between a binary state. The default appearance is a checkbox.\nFields of type `string` can be configured as a textarea element, which allows for multi-line text. The default appearance is a single-line input.\n\nIf a field type does not support a certain `ui:widget`, the setting is ignored.\n\n\nSee more: [Field Schema](https://schema.laboperator.com/schemas/definitions/field) "
+                            "description": "A flag indicating the widget variant for fields of type `string` or `boolean`. All other field types ignore this setting.\nBoolean fields can be displayed as either a checkbox or a switch to toggle between a binary state. The default appearance is a checkbox. Fields of type `string` can be configured as a multi-line textarea element. Their default appearance is a single-line input.\n",
+                            "markdownDescription": "A flag indicating the widget variant for fields of type `string` or `boolean`. All other field types ignore this setting.\nBoolean fields can be displayed as either a checkbox or a switch to toggle between a binary state. The default appearance is a checkbox. Fields of type `string` can be configured as a multi-line textarea element. Their default appearance is a single-line input.\n\n\nSee more: [Field Schema](https://schema.laboperator.com/schemas/definitions/field) "
                         },
                         "ui:options": {
                             "type": "object",

--- a/dist/workflow_template_schema.json
+++ b/dist/workflow_template_schema.json
@@ -454,11 +454,11 @@
                             "enum": [
                                 "checkbox",
                                 "switch",
-                                "textarea",
-                                "input"
+                                "text",
+                                "textarea"
                             ],
-                            "description": "A flag indicating the widget variant for fields of type `string` or `boolean`. All other field types ignore this setting.\nBoolean fields can be displayed as either a checkbox or a switch to toggle between a binary state. The default appearance is a checkbox. Fields of type `string` can be configured as a multi-line textarea element. Their default appearance is a single-line input.\n",
-                            "markdownDescription": "A flag indicating the widget variant for fields of type `string` or `boolean`. All other field types ignore this setting.\nBoolean fields can be displayed as either a checkbox or a switch to toggle between a binary state. The default appearance is a checkbox. Fields of type `string` can be configured as a multi-line textarea element. Their default appearance is a single-line input.\n\n\nSee more: [Field Schema](https://schema.laboperator.com/schemas/definitions/field) "
+                            "description": "A flag indicating the widget variant for fields of type `string` or `boolean`. All other field types ignore this setting.\nBoolean fields can be displayed as either a checkbox or a switch to toggle between a binary state. The default appearance is a checkbox. Fields of type `string` can be configured as a multi-line textarea element. Their default appearance is a single-line text input.\n",
+                            "markdownDescription": "A flag indicating the widget variant for fields of type `string` or `boolean`. All other field types ignore this setting.\nBoolean fields can be displayed as either a checkbox or a switch to toggle between a binary state. The default appearance is a checkbox. Fields of type `string` can be configured as a multi-line textarea element. Their default appearance is a single-line text input.\n\n\nSee more: [Field Schema](https://schema.laboperator.com/schemas/definitions/field) "
                         },
                         "ui:options": {
                             "type": "object",

--- a/dist/workflow_template_schema.json
+++ b/dist/workflow_template_schema.json
@@ -454,10 +454,11 @@
                             "enum": [
                                 "checkbox",
                                 "switch",
-                                "textarea"
+                                "textarea",
+                                "input"
                             ],
-                            "description": "A flag indicating the widget variant for fields of type `string` or `boolean`.\n\nBoolean fields can be displayed as either a checkbox or a switch to toggle between a binary state. The default appearance is a checkbox.\nFields of type `string` can be configured as a textarea element, which allows for multi-line text. The default appearance is a single-line input.\n\nIf a field type does not support a certain `ui:widget`, the setting is ignored.\n",
-                            "markdownDescription": "A flag indicating the widget variant for fields of type `string` or `boolean`.\n\nBoolean fields can be displayed as either a checkbox or a switch to toggle between a binary state. The default appearance is a checkbox.\nFields of type `string` can be configured as a textarea element, which allows for multi-line text. The default appearance is a single-line input.\n\nIf a field type does not support a certain `ui:widget`, the setting is ignored.\n\n\nSee more: [Field Schema](https://schema.laboperator.com/schemas/definitions/field) "
+                            "description": "A flag indicating the widget variant for fields of type `string` or `boolean`. All other field types ignore this setting.\nBoolean fields can be displayed as either a checkbox or a switch to toggle between a binary state. The default appearance is a checkbox. Fields of type `string` can be configured as a multi-line textarea element. Their default appearance is a single-line input.\n",
+                            "markdownDescription": "A flag indicating the widget variant for fields of type `string` or `boolean`. All other field types ignore this setting.\nBoolean fields can be displayed as either a checkbox or a switch to toggle between a binary state. The default appearance is a checkbox. Fields of type `string` can be configured as a multi-line textarea element. Their default appearance is a single-line input.\n\n\nSee more: [Field Schema](https://schema.laboperator.com/schemas/definitions/field) "
                         },
                         "ui:options": {
                             "type": "object",

--- a/src/schemata/definitions/field.yml
+++ b/src/schemata/definitions/field.yml
@@ -8,14 +8,10 @@ allOf:
     properties:
       ui:widget:
         type: string
-        enum: ['checkbox', 'switch', 'textarea']
+        enum: ['checkbox', 'switch', 'textarea', 'input']
         description: |
-          A flag indicating the widget variant for fields of type `string` or `boolean`.
-
-          Boolean fields can be displayed as either a checkbox or a switch to toggle between a binary state. The default appearance is a checkbox.
-          Fields of type `string` can be configured as a textarea element, which allows for multi-line text. The default appearance is a single-line input.
-
-          If a field type does not support a certain `ui:widget`, the setting is ignored.
+          A flag indicating the widget variant for fields of type `string` or `boolean`. All other field types ignore this setting.
+          Boolean fields can be displayed as either a checkbox or a switch to toggle between a binary state. The default appearance is a checkbox. Fields of type `string` can be configured as a multi-line textarea element. Their default appearance is a single-line input.
       ui:options:
         type: object
         description: |

--- a/src/schemata/definitions/field.yml
+++ b/src/schemata/definitions/field.yml
@@ -8,10 +8,10 @@ allOf:
     properties:
       ui:widget:
         type: string
-        enum: ['checkbox', 'switch', 'textarea', 'input']
+        enum: ['checkbox', 'switch', 'text', 'textarea']
         description: |
           A flag indicating the widget variant for fields of type `string` or `boolean`. All other field types ignore this setting.
-          Boolean fields can be displayed as either a checkbox or a switch to toggle between a binary state. The default appearance is a checkbox. Fields of type `string` can be configured as a multi-line textarea element. Their default appearance is a single-line input.
+          Boolean fields can be displayed as either a checkbox or a switch to toggle between a binary state. The default appearance is a checkbox. Fields of type `string` can be configured as a multi-line textarea element. Their default appearance is a single-line text input.
       ui:options:
         type: object
         description: |


### PR DESCRIPTION
### Description

Adds a default widget for string fields to be consistent with the implementation for boolean fields.
