### PR TITLE
changed string validation for channel names in elements

### DIFF
--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -2079,7 +2079,10 @@ export declare const schemas: {
                                     channels: {
                                         type: string;
                                         items: {
-                                            $ref: string;
+                                            type: string;
+                                            description: string;
+                                            pattern: string;
+                                            markdownDescription: string;
                                         };
                                     };
                                 };
@@ -5887,7 +5890,10 @@ export declare const schemas: {
                                     channels: {
                                         type: string;
                                         items: {
-                                            $ref: string;
+                                            type: string;
+                                            description: string;
+                                            pattern: string;
+                                            markdownDescription: string;
                                         };
                                     };
                                 };
@@ -9718,7 +9724,10 @@ export declare const schemas: {
                                     channels: {
                                         type: string;
                                         items: {
-                                            $ref: string;
+                                            type: string;
+                                            description: string;
+                                            pattern: string;
+                                            markdownDescription: string;
                                         };
                                     };
                                 };

--- a/dist/workflow-event-schema.json
+++ b/dist/workflow-event-schema.json
@@ -2628,7 +2628,10 @@
                                     "channels": {
                                         "type": "array",
                                         "items": {
-                                            "$ref": "#/definitions/member-name"
+                                            "type": "string",
+                                            "description": "A channel name that is present on the specified device.\nAllowed characters are lower \"a\" to \"z\", capital \"A\" to \"Z\", \"0\" to \"9\", \"/\" and \"_\".\n",
+                                            "pattern": "(?=^[a-zA-Z0-9_/]+$)",
+                                            "markdownDescription": "A channel name that is present on the specified device.\nAllowed characters are lower \"a\" to \"z\", capital \"A\" to \"Z\", \"0\" to \"9\", \"/\" and \"_\".\n\n\nSee more: [Input Channels Schema](https://schema.laboperator.com/schemas/definitions/step/element-objects/input-channels) "
                                         }
                                     }
                                 }

--- a/dist/workflow-event-schema.json
+++ b/dist/workflow-event-schema.json
@@ -2629,9 +2629,9 @@
                                         "type": "array",
                                         "items": {
                                             "type": "string",
-                                            "description": "A channel name that is present on the specified device.\nAllowed characters are lower \"a\" to \"z\", capital \"A\" to \"Z\", \"0\" to \"9\", \"/\" and \"_\".\n",
+                                            "description": "A channel name that is present on the specified device. Allowed characters are lower \"a\" to \"z\", capital \"A\" to \"Z\", \"0\" to \"9\", \"/\" and \"_\".\n",
                                             "pattern": "(?=^[a-zA-Z0-9_/]+$)",
-                                            "markdownDescription": "A channel name that is present on the specified device.\nAllowed characters are lower \"a\" to \"z\", capital \"A\" to \"Z\", \"0\" to \"9\", \"/\" and \"_\".\n\n\nSee more: [Input Channels Schema](https://schema.laboperator.com/schemas/definitions/step/element-objects/input-channels) "
+                                            "markdownDescription": "A channel name that is present on the specified device. Allowed characters are lower \"a\" to \"z\", capital \"A\" to \"Z\", \"0\" to \"9\", \"/\" and \"_\".\n\n\nSee more: [Input Channels Schema](https://schema.laboperator.com/schemas/definitions/step/element-objects/input-channels) "
                                         }
                                     }
                                 }

--- a/dist/workflow-step-template-schema.json
+++ b/dist/workflow-step-template-schema.json
@@ -2625,7 +2625,10 @@
                                     "channels": {
                                         "type": "array",
                                         "items": {
-                                            "$ref": "#/definitions/member-name"
+                                            "type": "string",
+                                            "description": "A channel name that is present on the specified device.\nAllowed characters are lower \"a\" to \"z\", capital \"A\" to \"Z\", \"0\" to \"9\", \"/\" and \"_\".\n",
+                                            "pattern": "(?=^[a-zA-Z0-9_/]+$)",
+                                            "markdownDescription": "A channel name that is present on the specified device.\nAllowed characters are lower \"a\" to \"z\", capital \"A\" to \"Z\", \"0\" to \"9\", \"/\" and \"_\".\n\n\nSee more: [Input Channels Schema](https://schema.laboperator.com/schemas/definitions/step/element-objects/input-channels) "
                                         }
                                     }
                                 }

--- a/dist/workflow-step-template-schema.json
+++ b/dist/workflow-step-template-schema.json
@@ -2626,9 +2626,9 @@
                                         "type": "array",
                                         "items": {
                                             "type": "string",
-                                            "description": "A channel name that is present on the specified device.\nAllowed characters are lower \"a\" to \"z\", capital \"A\" to \"Z\", \"0\" to \"9\", \"/\" and \"_\".\n",
+                                            "description": "A channel name that is present on the specified device. Allowed characters are lower \"a\" to \"z\", capital \"A\" to \"Z\", \"0\" to \"9\", \"/\" and \"_\".\n",
                                             "pattern": "(?=^[a-zA-Z0-9_/]+$)",
-                                            "markdownDescription": "A channel name that is present on the specified device.\nAllowed characters are lower \"a\" to \"z\", capital \"A\" to \"Z\", \"0\" to \"9\", \"/\" and \"_\".\n\n\nSee more: [Input Channels Schema](https://schema.laboperator.com/schemas/definitions/step/element-objects/input-channels) "
+                                            "markdownDescription": "A channel name that is present on the specified device. Allowed characters are lower \"a\" to \"z\", capital \"A\" to \"Z\", \"0\" to \"9\", \"/\" and \"_\".\n\n\nSee more: [Input Channels Schema](https://schema.laboperator.com/schemas/definitions/step/element-objects/input-channels) "
                                         }
                                     }
                                 }

--- a/dist/workflow-template-schema.json
+++ b/dist/workflow-template-schema.json
@@ -2652,9 +2652,9 @@
                                         "type": "array",
                                         "items": {
                                             "type": "string",
-                                            "description": "A channel name that is present on the specified device.\nAllowed characters are lower \"a\" to \"z\", capital \"A\" to \"Z\", \"0\" to \"9\", \"/\" and \"_\".\n",
+                                            "description": "A channel name that is present on the specified device. Allowed characters are lower \"a\" to \"z\", capital \"A\" to \"Z\", \"0\" to \"9\", \"/\" and \"_\".\n",
                                             "pattern": "(?=^[a-zA-Z0-9_/]+$)",
-                                            "markdownDescription": "A channel name that is present on the specified device.\nAllowed characters are lower \"a\" to \"z\", capital \"A\" to \"Z\", \"0\" to \"9\", \"/\" and \"_\".\n\n\nSee more: [Input Channels Schema](https://schema.laboperator.com/schemas/definitions/step/element-objects/input-channels) "
+                                            "markdownDescription": "A channel name that is present on the specified device. Allowed characters are lower \"a\" to \"z\", capital \"A\" to \"Z\", \"0\" to \"9\", \"/\" and \"_\".\n\n\nSee more: [Input Channels Schema](https://schema.laboperator.com/schemas/definitions/step/element-objects/input-channels) "
                                         }
                                     }
                                 }

--- a/dist/workflow-template-schema.json
+++ b/dist/workflow-template-schema.json
@@ -2651,7 +2651,10 @@
                                     "channels": {
                                         "type": "array",
                                         "items": {
-                                            "$ref": "#/definitions/member-name"
+                                            "type": "string",
+                                            "description": "A channel name that is present on the specified device.\nAllowed characters are lower \"a\" to \"z\", capital \"A\" to \"Z\", \"0\" to \"9\", \"/\" and \"_\".\n",
+                                            "pattern": "(?=^[a-zA-Z0-9_/]+$)",
+                                            "markdownDescription": "A channel name that is present on the specified device.\nAllowed characters are lower \"a\" to \"z\", capital \"A\" to \"Z\", \"0\" to \"9\", \"/\" and \"_\".\n\n\nSee more: [Input Channels Schema](https://schema.laboperator.com/schemas/definitions/step/element-objects/input-channels) "
                                         }
                                     }
                                 }

--- a/src/schemata/definitions/step/element-objects/input-channels.yml
+++ b/src/schemata/definitions/step/element-objects/input-channels.yml
@@ -17,7 +17,5 @@ items:
           items:
             type: string # channel names
             description: |
-              A channel name that is present on the specified device.
-              Allowed characters are lower "a" to "z", capital "A" to "Z", "0" to "9", "/" and "_".
+              A channel name that is present on the specified device. Allowed characters are lower "a" to "z", capital "A" to "Z", "0" to "9", "/" and "_".
             pattern: (?=^[a-zA-Z0-9_/]+$)
-

--- a/src/schemata/definitions/step/element-objects/input-channels.yml
+++ b/src/schemata/definitions/step/element-objects/input-channels.yml
@@ -15,4 +15,9 @@ items:
         channels:
           type: array
           items:
-            $ref: '#/definitions/member-name' # channel names
+            type: string # channel names
+            description: |
+              A channel name that is present on the specified device.
+              Allowed characters are lower "a" to "z", capital "A" to "Z", "0" to "9", "/" and "_".
+            pattern: (?=^[a-zA-Z0-9_/]+$)
+

--- a/src/workflow-event-schema.json
+++ b/src/workflow-event-schema.json
@@ -2628,7 +2628,10 @@
                   "channels": {
                     "type": "array",
                     "items": {
-                      "$ref": "#/definitions/member-name"
+                      "type": "string",
+                      "description": "A channel name that is present on the specified device.\nAllowed characters are lower \"a\" to \"z\", capital \"A\" to \"Z\", \"0\" to \"9\", \"/\" and \"_\".\n",
+                      "pattern": "(?=^[a-zA-Z0-9_/]+$)",
+                      "markdownDescription": "A channel name that is present on the specified device.\nAllowed characters are lower \"a\" to \"z\", capital \"A\" to \"Z\", \"0\" to \"9\", \"/\" and \"_\".\n\n\nSee more: [Input Channels Schema](https://schema.laboperator.com/schemas/definitions/step/element-objects/input-channels) "
                     }
                   }
                 }

--- a/src/workflow-event-schema.json
+++ b/src/workflow-event-schema.json
@@ -2629,9 +2629,9 @@
                     "type": "array",
                     "items": {
                       "type": "string",
-                      "description": "A channel name that is present on the specified device.\nAllowed characters are lower \"a\" to \"z\", capital \"A\" to \"Z\", \"0\" to \"9\", \"/\" and \"_\".\n",
+                      "description": "A channel name that is present on the specified device. Allowed characters are lower \"a\" to \"z\", capital \"A\" to \"Z\", \"0\" to \"9\", \"/\" and \"_\".\n",
                       "pattern": "(?=^[a-zA-Z0-9_/]+$)",
-                      "markdownDescription": "A channel name that is present on the specified device.\nAllowed characters are lower \"a\" to \"z\", capital \"A\" to \"Z\", \"0\" to \"9\", \"/\" and \"_\".\n\n\nSee more: [Input Channels Schema](https://schema.laboperator.com/schemas/definitions/step/element-objects/input-channels) "
+                      "markdownDescription": "A channel name that is present on the specified device. Allowed characters are lower \"a\" to \"z\", capital \"A\" to \"Z\", \"0\" to \"9\", \"/\" and \"_\".\n\n\nSee more: [Input Channels Schema](https://schema.laboperator.com/schemas/definitions/step/element-objects/input-channels) "
                     }
                   }
                 }

--- a/src/workflow-step-template-schema.json
+++ b/src/workflow-step-template-schema.json
@@ -2626,9 +2626,9 @@
                     "type": "array",
                     "items": {
                       "type": "string",
-                      "description": "A channel name that is present on the specified device.\nAllowed characters are lower \"a\" to \"z\", capital \"A\" to \"Z\", \"0\" to \"9\", \"/\" and \"_\".\n",
+                      "description": "A channel name that is present on the specified device. Allowed characters are lower \"a\" to \"z\", capital \"A\" to \"Z\", \"0\" to \"9\", \"/\" and \"_\".\n",
                       "pattern": "(?=^[a-zA-Z0-9_/]+$)",
-                      "markdownDescription": "A channel name that is present on the specified device.\nAllowed characters are lower \"a\" to \"z\", capital \"A\" to \"Z\", \"0\" to \"9\", \"/\" and \"_\".\n\n\nSee more: [Input Channels Schema](https://schema.laboperator.com/schemas/definitions/step/element-objects/input-channels) "
+                      "markdownDescription": "A channel name that is present on the specified device. Allowed characters are lower \"a\" to \"z\", capital \"A\" to \"Z\", \"0\" to \"9\", \"/\" and \"_\".\n\n\nSee more: [Input Channels Schema](https://schema.laboperator.com/schemas/definitions/step/element-objects/input-channels) "
                     }
                   }
                 }

--- a/src/workflow-step-template-schema.json
+++ b/src/workflow-step-template-schema.json
@@ -2625,7 +2625,10 @@
                   "channels": {
                     "type": "array",
                     "items": {
-                      "$ref": "#/definitions/member-name"
+                      "type": "string",
+                      "description": "A channel name that is present on the specified device.\nAllowed characters are lower \"a\" to \"z\", capital \"A\" to \"Z\", \"0\" to \"9\", \"/\" and \"_\".\n",
+                      "pattern": "(?=^[a-zA-Z0-9_/]+$)",
+                      "markdownDescription": "A channel name that is present on the specified device.\nAllowed characters are lower \"a\" to \"z\", capital \"A\" to \"Z\", \"0\" to \"9\", \"/\" and \"_\".\n\n\nSee more: [Input Channels Schema](https://schema.laboperator.com/schemas/definitions/step/element-objects/input-channels) "
                     }
                   }
                 }

--- a/src/workflow-template-schema.json
+++ b/src/workflow-template-schema.json
@@ -2651,7 +2651,10 @@
                   "channels": {
                     "type": "array",
                     "items": {
-                      "$ref": "#/definitions/member-name"
+                      "type": "string",
+                      "description": "A channel name that is present on the specified device.\nAllowed characters are lower \"a\" to \"z\", capital \"A\" to \"Z\", \"0\" to \"9\", \"/\" and \"_\".\n",
+                      "pattern": "(?=^[a-zA-Z0-9_/]+$)",
+                      "markdownDescription": "A channel name that is present on the specified device.\nAllowed characters are lower \"a\" to \"z\", capital \"A\" to \"Z\", \"0\" to \"9\", \"/\" and \"_\".\n\n\nSee more: [Input Channels Schema](https://schema.laboperator.com/schemas/definitions/step/element-objects/input-channels) "
                     }
                   }
                 }

--- a/src/workflow-template-schema.json
+++ b/src/workflow-template-schema.json
@@ -2652,9 +2652,9 @@
                     "type": "array",
                     "items": {
                       "type": "string",
-                      "description": "A channel name that is present on the specified device.\nAllowed characters are lower \"a\" to \"z\", capital \"A\" to \"Z\", \"0\" to \"9\", \"/\" and \"_\".\n",
+                      "description": "A channel name that is present on the specified device. Allowed characters are lower \"a\" to \"z\", capital \"A\" to \"Z\", \"0\" to \"9\", \"/\" and \"_\".\n",
                       "pattern": "(?=^[a-zA-Z0-9_/]+$)",
-                      "markdownDescription": "A channel name that is present on the specified device.\nAllowed characters are lower \"a\" to \"z\", capital \"A\" to \"Z\", \"0\" to \"9\", \"/\" and \"_\".\n\n\nSee more: [Input Channels Schema](https://schema.laboperator.com/schemas/definitions/step/element-objects/input-channels) "
+                      "markdownDescription": "A channel name that is present on the specified device. Allowed characters are lower \"a\" to \"z\", capital \"A\" to \"Z\", \"0\" to \"9\", \"/\" and \"_\".\n\n\nSee more: [Input Channels Schema](https://schema.laboperator.com/schemas/definitions/step/element-objects/input-channels) "
                     }
                   }
                 }


### PR DESCRIPTION
Just a small change to the validation schema assigned for the names of input channels when defining elements in a workflow template. Currently, the validation for "member name" is used, which only allows for a limited selection of special characters, excluding `/`.This symbol is used when naming SiLA channels and is therefore required. After discussing with the connectivity team, the validation rule provided in my branch suffices. I just need someone to build the schema again, as I was unable to do so. :'(
