### PR TITLE
[WFE-56] Trigger schema  docs release when workflow schema is updated

### DIFF
--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -1,0 +1,18 @@
+name: 'Deploy Schema Docs'
+
+on:
+  push:
+    branches:
+      - "main"
+
+jobs:
+  deploy-docs:
+    if: github.actor != dependabot[bot]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger Deploy workflow
+        uses: CircleCI-Public/trigger-circleci-pipeline-action@v1.0.5
+        with:
+          target-slug: github/labforward/laboperator-schema-docs
+        env:
+          CCI_TOKEN: ${{ secrets.CCI_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - [[CUB-4282]](https://labforward.atlassian.net/browse/CUB-4282) [Workflows] Add get resources template schema
 - [[CUB-4622]](https://labforward.atlassian.net/browse/CUB-4622) [Workflows] Add Workflow Event to the schemata definitions
 - [[CUB-4622]](https://labforward.atlassian.net/browse/CUB-4622) [Workflows] Change definition references to dashed-case
+- [[WFE-56]](https://labforward.atlassian.net/browse/WFE-56) [Documentation] Trigger schema  docs release when workflow schema is updated
 
 ### Changed
 


### PR DESCRIPTION
### [WFE-56]

### Description

This is my proposed solution to triggering the deploy on laboperator-schema-docs repository whenever changes are pushed to the workflow schema.

To work, it will require adding `CCI_TOKEN` secret to the repo, which is a personal token (preferably for a machine user).

The [corresponding changes to `config.yml` on the schema-docs repo](https://github.com/labforward/laboperator-schema-docs/pull/28) also need to be merged.

### Manual PR Checklist

- [x] CHANGELOG entry added
- [x] ~Test coverage added~
- [x] Licenses checked
- [x] All related Jira tickets added to PR title
- [x] Description in Jira ticket is clear and up-to-date


[WFE-56]: https://labforward.atlassian.net/browse/WFE-56?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ