### PR TITLE
[chore] Set min length for required string fields

### DIFF
--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -744,6 +744,7 @@ export declare const schemas: {
                 properties: {
                     title: {
                         type: string;
+                        minLength: number;
                         maxLength: number;
                         description: string;
                         examples: string[];
@@ -1308,6 +1309,7 @@ export declare const schemas: {
                             properties: {
                                 title: {
                                     type: string;
+                                    minLength: number;
                                     description: string;
                                     markdownDescription: string;
                                 };
@@ -2898,7 +2900,7 @@ export declare const schemas: {
                     properties: {
                         title: {
                             type: string;
-                            title: string;
+                            minLength: number;
                             description: string;
                             examples: string[];
                             markdownDescription: string;
@@ -3879,6 +3881,7 @@ export declare const schemas: {
                 properties: {
                     title: {
                         type: string;
+                        minLength: number;
                         maxLength: number;
                         description: string;
                         examples: string[];
@@ -4952,6 +4955,7 @@ export declare const schemas: {
                                 properties: {
                                     title: {
                                         type: string;
+                                        minLength: number;
                                         maxLength: number;
                                         description: string;
                                         examples: string[];
@@ -5395,6 +5399,7 @@ export declare const schemas: {
                             properties: {
                                 title: {
                                     type: string;
+                                    minLength: number;
                                     description: string;
                                     markdownDescription: string;
                                 };
@@ -6227,7 +6232,7 @@ export declare const schemas: {
                     properties: {
                         title: {
                             type: string;
-                            title: string;
+                            minLength: number;
                             description: string;
                             examples: string[];
                             markdownDescription: string;

--- a/dist/workflow-step-template-schema.json
+++ b/dist/workflow-step-template-schema.json
@@ -335,6 +335,7 @@
             "properties": {
                 "title": {
                     "type": "string",
+                    "minLength": 1,
                     "maxLength": 200,
                     "description": "The display name of the template in Laboperator.\n",
                     "examples": [
@@ -1197,6 +1198,7 @@
                         "properties": {
                             "title": {
                                 "type": "string",
+                                "minLength": 1,
                                 "description": "A title to display on the alert.\n",
                                 "markdownDescription": "A title to display on the alert.\n\n\nSee more: [Alert Schema](https://schema.laboperator.com/schemas/definitions/workflow-template/action-objects/alert) "
                             },
@@ -3102,7 +3104,7 @@
                 "properties": {
                     "title": {
                         "type": "string",
-                        "title": "Title",
+                        "minLength": 1,
                         "description": "The displayed title of the page.\n",
                         "examples": [
                             "Formula"

--- a/dist/workflow-template-schema.json
+++ b/dist/workflow-template-schema.json
@@ -321,6 +321,7 @@
             "properties": {
                 "title": {
                     "type": "string",
+                    "minLength": 1,
                     "maxLength": 200,
                     "description": "The display name of the template in Laboperator.\n",
                     "examples": [
@@ -1587,6 +1588,7 @@
                                 "properties": {
                                     "title": {
                                         "type": "string",
+                                        "minLength": 1,
                                         "maxLength": 100,
                                         "description": "The display name of the step in Laboperator.\n",
                                         "examples": [
@@ -2322,6 +2324,7 @@
                         "properties": {
                             "title": {
                                 "type": "string",
+                                "minLength": 1,
                                 "description": "A title to display on the alert.\n",
                                 "markdownDescription": "A title to display on the alert.\n\n\nSee more: [Alert Schema](https://schema.laboperator.com/schemas/definitions/workflow-template/action-objects/alert) "
                             },
@@ -3312,7 +3315,7 @@
                 "properties": {
                     "title": {
                         "type": "string",
-                        "title": "Title",
+                        "minLength": 1,
                         "description": "The displayed title of the page.\n",
                         "examples": [
                             "Formula"

--- a/src/schemata/definitions/context/page.yml
+++ b/src/schemata/definitions/context/page.yml
@@ -9,7 +9,7 @@ required:
 properties:
   title:
     type: string
-    title: Title
+    minLength: 1
     description: |
       The displayed title of the page.
     examples:

--- a/src/schemata/definitions/info.yml
+++ b/src/schemata/definitions/info.yml
@@ -11,6 +11,7 @@ additionalProperties: false
 properties:
   title:
     type: string
+    minLength: 1
     maxLength: 200
     description: |
       The display name of the template in Laboperator.

--- a/src/schemata/definitions/workflow-template/action-objects/alert.yml
+++ b/src/schemata/definitions/workflow-template/action-objects/alert.yml
@@ -16,6 +16,7 @@ additionalProperties:
   properties:
     title:
       type: string
+      minLength: 1
       description: |
         A title to display on the alert.
     text:

--- a/src/schemata/definitions/workflow-template/step.yml
+++ b/src/schemata/definitions/workflow-template/step.yml
@@ -15,6 +15,7 @@ allOf:
         properties:
           title:
             type: string
+            minLength: 1
             maxLength: 100
             description: |
               The display name of the step in Laboperator.

--- a/src/workflow-step-template-schema.json
+++ b/src/workflow-step-template-schema.json
@@ -335,6 +335,7 @@
       "properties": {
         "title": {
           "type": "string",
+          "minLength": 1,
           "maxLength": 200,
           "description": "The display name of the template in Laboperator.\n",
           "examples": [
@@ -1197,6 +1198,7 @@
             "properties": {
               "title": {
                 "type": "string",
+                "minLength": 1,
                 "description": "A title to display on the alert.\n",
                 "markdownDescription": "A title to display on the alert.\n\n\nSee more: [Alert Schema](https://schema.laboperator.com/schemas/definitions/workflow-template/action-objects/alert) "
               },
@@ -3102,7 +3104,7 @@
         "properties": {
           "title": {
             "type": "string",
-            "title": "Title",
+            "minLength": 1,
             "description": "The displayed title of the page.\n",
             "examples": [
               "Formula"

--- a/src/workflow-template-schema.json
+++ b/src/workflow-template-schema.json
@@ -321,6 +321,7 @@
       "properties": {
         "title": {
           "type": "string",
+          "minLength": 1,
           "maxLength": 200,
           "description": "The display name of the template in Laboperator.\n",
           "examples": [
@@ -1587,6 +1588,7 @@
                 "properties": {
                   "title": {
                     "type": "string",
+                    "minLength": 1,
                     "maxLength": 100,
                     "description": "The display name of the step in Laboperator.\n",
                     "examples": [
@@ -2322,6 +2324,7 @@
             "properties": {
               "title": {
                 "type": "string",
+                "minLength": 1,
                 "description": "A title to display on the alert.\n",
                 "markdownDescription": "A title to display on the alert.\n\n\nSee more: [Alert Schema](https://schema.laboperator.com/schemas/definitions/workflow-template/action-objects/alert) "
               },
@@ -3312,7 +3315,7 @@
         "properties": {
           "title": {
             "type": "string",
-            "title": "Title",
+            "minLength": 1,
             "description": "The displayed title of the page.\n",
             "examples": [
               "Formula"


### PR DESCRIPTION
The `required` keyword does not validate the value of a property, instead it only checks its existence. [Section 6.5.3](https://datatracker.ietf.org/doc/html/draft-handrews-json-schema-validation-01#section-6.5.3):

> An object instance is valid against this keyword if every item in the array is the name of a property in the instance.

In other words, uploading a template with `''` as its title will pass validation. Aside from this not being our intended behavior of the current schema definition, this creates issues within the WFE, which does not accept an empty string as a valid value for required string fields. If we were to support that in the WFE, we would have no way of displaying errors when the user clears a required textfield.