### PR TITLE
[CUB-4985] Allow interpolation of Email address in the sendEmail action

### DIFF
--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -1597,7 +1597,6 @@ export declare const schemas: {
                             properties: {
                                 to: {
                                     type: string;
-                                    format: string;
                                     description: string;
                                     markdownDescription: string;
                                 };
@@ -5731,7 +5730,6 @@ export declare const schemas: {
                             properties: {
                                 to: {
                                     type: string;
-                                    format: string;
                                     description: string;
                                     markdownDescription: string;
                                 };

--- a/dist/workflow-step-template-schema.json
+++ b/dist/workflow-step-template-schema.json
@@ -1552,7 +1552,6 @@
                         "properties": {
                             "to": {
                                 "type": "string",
-                                "format": "email",
                                 "description": "Recipient's e-mail address",
                                 "markdownDescription": "Recipient's e-mail address\n\nSee more: [Send Email Schema](https://schema.laboperator.com/schemas/definitions/workflow-template/action-objects/send-email) "
                             },

--- a/dist/workflow-template-schema.json
+++ b/dist/workflow-template-schema.json
@@ -2684,7 +2684,6 @@
                         "properties": {
                             "to": {
                                 "type": "string",
-                                "format": "email",
                                 "description": "Recipient's e-mail address",
                                 "markdownDescription": "Recipient's e-mail address\n\nSee more: [Send Email Schema](https://schema.laboperator.com/schemas/definitions/workflow-template/action-objects/send-email) "
                             },

--- a/src/schemata/definitions/workflow-template/action-objects/send-email.yml
+++ b/src/schemata/definitions/workflow-template/action-objects/send-email.yml
@@ -18,7 +18,6 @@ additionalProperties:
   properties:
     to:
       type: string
-      format: email
       description: Recipient's e-mail address
     subject:
       type: string

--- a/src/workflow-step-template-schema.json
+++ b/src/workflow-step-template-schema.json
@@ -1552,7 +1552,6 @@
             "properties": {
               "to": {
                 "type": "string",
-                "format": "email",
                 "description": "Recipient's e-mail address",
                 "markdownDescription": "Recipient's e-mail address\n\nSee more: [Send Email Schema](https://schema.laboperator.com/schemas/definitions/workflow-template/action-objects/send-email) "
               },

--- a/src/workflow-template-schema.json
+++ b/src/workflow-template-schema.json
@@ -2684,7 +2684,6 @@
             "properties": {
               "to": {
                 "type": "string",
-                "format": "email",
                 "description": "Recipient's e-mail address",
                 "markdownDescription": "Recipient's e-mail address\n\nSee more: [Send Email Schema](https://schema.laboperator.com/schemas/definitions/workflow-template/action-objects/send-email) "
               },


### PR DESCRIPTION
### [CUB-4985]


[CUB-4985]: https://labforward.atlassian.net/browse/CUB-4985?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


Removed `format: email` from `to:` property