### PR TITLE
automatically dedupe yarn dependencies

### DIFF
--- a/.github/workflows/dependabot_dedupe.yml
+++ b/.github/workflows/dependabot_dedupe.yml
@@ -1,0 +1,31 @@
+name: Dedupe Dependabot PRs
+
+on:
+  push:
+    branches: ['dependabot/npm_and_yarn/**']
+
+jobs:
+  dedupe:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: fregante/setup-git-user@v1
+
+      - name: Use Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: lts/*
+
+      - name: Dedupe if needed
+        env:
+          HUSKY: 0
+        run: |
+          corepack enable
+          yarn dedupe
+
+          if [[ -n $(git status -s) ]]; then
+            git add .
+            git commit -m '[dependabot skip] Dedupe dependencies'
+            git push
+          fi

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,9 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-yarn pre-commit
+if [ -n "$(git diff --name-only --staged | grep 'yarn.lock')" ]; then
+  yarn dedupe
+  git add -u
+fi
+
+yarn lint-staged

--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
     "dev": "nodemon src/compile.ts & nodemon src/validation.ts",
     "format": "prettier --write 'src/**/*.{ts,js}'",
     "lint": "eslint --fix 'src/**/*.{ts,js}'",
-    "pre-commit": "lint-staged",
     "prepare": "husky install",
     "sort": "sort-package-json package.json",
     "test": "jest --runInBand",


### PR DESCRIPTION
dependabot doesn't run pre-commit hooks,
so it needs a separate github action

- PR with duplicated dependencies:

  ![image](https://github.com/labforward/laboperator-workflow-schema/assets/667726/ecd5afd3-cb5c-4e0d-91b7-6ca9cc21465c)

- after dedupe:

  ![image](https://github.com/labforward/laboperator-workflow-schema/assets/667726/426a42b0-bdc8-4932-8270-920137e06992)

- [example action run](https://github.com/labforward/markdown-parser/actions/runs/6901854309/job/18777441457)

  ![image](https://github.com/labforward/laboperator-workflow-schema/assets/667726/144aeceb-e10e-4cb9-a63c-d90f9de93c5f)
