### PR TITLE
[CUB-5083] Enable device name as an updatable property when using update_resources action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - [[CUB-4622]](https://labforward.atlassian.net/browse/CUB-4622) [Workflows] Change definition references to dashed-case
 - [[CUB-4771]](https://labforward.atlassian.net/browse/CUB-4771) [Workflows] Add oidc interceptor to webhook schema
 - [[CUB-4985]](https://labforward.atlassian.net/browse/CUB-4985) [Workflows] Add sendEmail action to workflows
+- [[CUB-5083]](https://labforward.atlassian.net/browse/CUB-5083) [Workflows] Enable device name as an updatable property when using update_resources action
 
 ### Changed
 

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -1923,9 +1923,10 @@ export declare const schemas: {
                                                     description: string;
                                                     markdownDescription: string;
                                                 };
-                                                title: {
+                                                name: {
                                                     $ref: string;
                                                 };
+                                                title?: undefined;
                                             };
                                         };
                                     };
@@ -1946,6 +1947,31 @@ export declare const schemas: {
                                                     description: string;
                                                     markdownDescription: string;
                                                 };
+                                                title: {
+                                                    $ref: string;
+                                                };
+                                                name?: undefined;
+                                            };
+                                        };
+                                    };
+                                } | {
+                                    type: string;
+                                    required: string[];
+                                    properties: {
+                                        type: {
+                                            type: string;
+                                            enum: string[];
+                                        };
+                                        attributes: {
+                                            type: string;
+                                            additionalProperties: boolean;
+                                            properties: {
+                                                custom_attributes: {
+                                                    $ref: string;
+                                                    description: string;
+                                                    markdownDescription: string;
+                                                };
+                                                name?: undefined;
                                                 title?: undefined;
                                             };
                                         };
@@ -1961,7 +1987,18 @@ export declare const schemas: {
                                 id: string;
                                 type: string;
                                 attributes: {
+                                    name: string;
+                                    title?: undefined;
+                                    custom_attributes?: undefined;
+                                };
+                            };
+                        } | {
+                            update_resource: {
+                                id: string;
+                                type: string;
+                                attributes: {
                                     title: string;
+                                    name?: undefined;
                                     custom_attributes?: undefined;
                                 };
                             };
@@ -1971,6 +2008,7 @@ export declare const schemas: {
                                 type: string;
                                 attributes: {
                                     custom_attributes: string;
+                                    name?: undefined;
                                     title?: undefined;
                                 };
                             };
@@ -6056,9 +6094,10 @@ export declare const schemas: {
                                                     description: string;
                                                     markdownDescription: string;
                                                 };
-                                                title: {
+                                                name: {
                                                     $ref: string;
                                                 };
+                                                title?: undefined;
                                             };
                                         };
                                     };
@@ -6079,6 +6118,31 @@ export declare const schemas: {
                                                     description: string;
                                                     markdownDescription: string;
                                                 };
+                                                title: {
+                                                    $ref: string;
+                                                };
+                                                name?: undefined;
+                                            };
+                                        };
+                                    };
+                                } | {
+                                    type: string;
+                                    required: string[];
+                                    properties: {
+                                        type: {
+                                            type: string;
+                                            enum: string[];
+                                        };
+                                        attributes: {
+                                            type: string;
+                                            additionalProperties: boolean;
+                                            properties: {
+                                                custom_attributes: {
+                                                    $ref: string;
+                                                    description: string;
+                                                    markdownDescription: string;
+                                                };
+                                                name?: undefined;
                                                 title?: undefined;
                                             };
                                         };
@@ -6094,7 +6158,18 @@ export declare const schemas: {
                                 id: string;
                                 type: string;
                                 attributes: {
+                                    name: string;
+                                    title?: undefined;
+                                    custom_attributes?: undefined;
+                                };
+                            };
+                        } | {
+                            update_resource: {
+                                id: string;
+                                type: string;
+                                attributes: {
                                     title: string;
+                                    name?: undefined;
                                     custom_attributes?: undefined;
                                 };
                             };
@@ -6104,6 +6179,7 @@ export declare const schemas: {
                                 type: string;
                                 attributes: {
                                     custom_attributes: string;
+                                    name?: undefined;
                                     title?: undefined;
                                 };
                             };

--- a/dist/workflow-step-template-schema.json
+++ b/dist/workflow-step-template-schema.json
@@ -1893,7 +1893,7 @@
                 "update-resource": {
                     "type": "object",
                     "title": "Update Resource",
-                    "description": "An action to update a resource. It can be used to update the value of custom attributes, and in case of Workflow Runs also update their title.\n",
+                    "description": "An action to update a resource. It can be used to update the value of custom attributes.\nIn case of Workflow Runs also update their title and name of Device.\n",
                     "propertyNames": {
                         "enum": [
                             "update_resource",
@@ -1922,6 +1922,35 @@
                             },
                             {
                                 "oneOf": [
+                                    {
+                                        "type": "object",
+                                        "required": [
+                                            "type",
+                                            "attributes"
+                                        ],
+                                        "properties": {
+                                            "type": {
+                                                "type": "string",
+                                                "enum": [
+                                                    "device"
+                                                ]
+                                            },
+                                            "attributes": {
+                                                "type": "object",
+                                                "additionalProperties": false,
+                                                "properties": {
+                                                    "custom_attributes": {
+                                                        "$ref": "#/definitions/script",
+                                                        "description": "To update a custom attribute, the script must resolve to a hash object with `name`, `type` and `value` attributes. The supported custom attribute data types are `number`, `text`, `boolean` (checkbox), `date`, `datetime`, `file`, `image`, `physicalQuantity`, `relation`, and `duration`.\n",
+                                                        "markdownDescription": "To update a custom attribute, the script must resolve to a hash object with `name`, `type` and `value` attributes. The supported custom attribute data types are `number`, `text`, `boolean` (checkbox), `date`, `datetime`, `file`, `image`, `physicalQuantity`, `relation`, and `duration`.\n\n\nSee more: [Update Resource Schema](https://schema.laboperator.com/schemas/definitions/workflow-template/action-objects/update-resource) "
+                                                    },
+                                                    "name": {
+                                                        "$ref": "#/definitions/script"
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    },
                                     {
                                         "type": "object",
                                         "required": [
@@ -1992,6 +2021,15 @@
                     "examples": [
                         {
                             "update_resource": {
+                                "id": "balance.id",
+                                "type": "device",
+                                "attributes": {
+                                    "name": "deviceField.name"
+                                }
+                            }
+                        },
+                        {
+                            "update_resource": {
                                 "id": "workflow_run.data.id",
                                 "type": "workflow_run",
                                 "attributes": {
@@ -2009,7 +2047,7 @@
                             }
                         }
                     ],
-                    "markdownDescription": "An action to update a resource. It can be used to update the value of custom attributes, and in case of Workflow Runs also update their title.\n\n\nSee more: [Update Resource Schema](https://schema.laboperator.com/schemas/definitions/workflow-template/action-objects/update-resource) "
+                    "markdownDescription": "An action to update a resource. It can be used to update the value of custom attributes.\nIn case of Workflow Runs also update their title and name of Device.\n\n\nSee more: [Update Resource Schema](https://schema.laboperator.com/schemas/definitions/workflow-template/action-objects/update-resource) "
                 },
                 "webhook": {
                     "type": "object",

--- a/dist/workflow-step-template-schema.json
+++ b/dist/workflow-step-template-schema.json
@@ -1893,7 +1893,7 @@
                 "update-resource": {
                     "type": "object",
                     "title": "Update Resource",
-                    "description": "An action to update a resource. It can be used to update the value of custom attributes.\nIn case of Workflow Runs also update their title and name of Device.\n",
+                    "description": "An action to update the value of custom attributes of a resource, as well as the title of a Workflow Run, or the name of a Device.\n",
                     "propertyNames": {
                         "enum": [
                             "update_resource",
@@ -2006,8 +2006,8 @@
                                                 "properties": {
                                                     "custom_attributes": {
                                                         "$ref": "#/definitions/script",
-                                                        "description": "To update a custom attribute, the script must evaluate to a hash object with `name`, `type` and `value` attributes. The supported custom attribute data types are `number`, `text`, `boolean` (checkbox), `date`, `datetime`, `file`, `image`, `physicalQuantity`, `relation`, and `duration`.\n",
-                                                        "markdownDescription": "To update a custom attribute, the script must evaluate to a hash object with `name`, `type` and `value` attributes. The supported custom attribute data types are `number`, `text`, `boolean` (checkbox), `date`, `datetime`, `file`, `image`, `physicalQuantity`, `relation`, and `duration`.\n\n\nSee more: [Update Resource Schema](https://schema.laboperator.com/schemas/definitions/workflow-template/action-objects/update-resource) "
+                                                        "description": "To update a custom attribute, the script must resolve to a hash object with `name`, `type` and `value` attributes. The supported custom attribute data types are `number`, `text`, `boolean` (checkbox), `date`, `datetime`, `file`, `image`, `physicalQuantity`, `relation`, and `duration`.\n",
+                                                        "markdownDescription": "To update a custom attribute, the script must resolve to a hash object with `name`, `type` and `value` attributes. The supported custom attribute data types are `number`, `text`, `boolean` (checkbox), `date`, `datetime`, `file`, `image`, `physicalQuantity`, `relation`, and `duration`.\n\n\nSee more: [Update Resource Schema](https://schema.laboperator.com/schemas/definitions/workflow-template/action-objects/update-resource) "
                                                     }
                                                 }
                                             }
@@ -2046,7 +2046,7 @@
                             }
                         }
                     ],
-                    "markdownDescription": "An action to update a resource. It can be used to update the value of custom attributes.\nIn case of Workflow Runs also update their title and name of Device.\n\n\nSee more: [Update Resource Schema](https://schema.laboperator.com/schemas/definitions/workflow-template/action-objects/update-resource) "
+                    "markdownDescription": "An action to update the value of custom attributes of a resource, as well as the title of a Workflow Run, or the name of a Device.\n\n\nSee more: [Update Resource Schema](https://schema.laboperator.com/schemas/definitions/workflow-template/action-objects/update-resource) "
                 },
                 "webhook": {
                     "type": "object",

--- a/dist/workflow-step-template-schema.json
+++ b/dist/workflow-step-template-schema.json
@@ -1993,7 +1993,6 @@
                                                     "collection",
                                                     "connector",
                                                     "dashboard",
-                                                    "device",
                                                     "export",
                                                     "measurement",
                                                     "sample",

--- a/dist/workflow-template-schema.json
+++ b/dist/workflow-template-schema.json
@@ -3024,7 +3024,7 @@
                 "update-resource": {
                     "type": "object",
                     "title": "Update Resource",
-                    "description": "An action to update a resource. It can be used to update the value of custom attributes.\nIn case of Workflow Runs also update their title and name of Device.\n",
+                    "description": "An action to update the value of custom attributes of a resource, as well as the title of a Workflow Run, or the name of a Device.\n",
                     "propertyNames": {
                         "enum": [
                             "update_resource",
@@ -3137,8 +3137,8 @@
                                                 "properties": {
                                                     "custom_attributes": {
                                                         "$ref": "#/definitions/script",
-                                                        "description": "To update a custom attribute, the script must evaluate to a hash object with `name`, `type` and `value` attributes. The supported custom attribute data types are `number`, `text`, `boolean` (checkbox), `date`, `datetime`, `file`, `image`, `physicalQuantity`, `relation`, and `duration`.\n",
-                                                        "markdownDescription": "To update a custom attribute, the script must evaluate to a hash object with `name`, `type` and `value` attributes. The supported custom attribute data types are `number`, `text`, `boolean` (checkbox), `date`, `datetime`, `file`, `image`, `physicalQuantity`, `relation`, and `duration`.\n\n\nSee more: [Update Resource Schema](https://schema.laboperator.com/schemas/definitions/workflow-template/action-objects/update-resource) "
+                                                        "description": "To update a custom attribute, the script must resolve to a hash object with `name`, `type` and `value` attributes. The supported custom attribute data types are `number`, `text`, `boolean` (checkbox), `date`, `datetime`, `file`, `image`, `physicalQuantity`, `relation`, and `duration`.\n",
+                                                        "markdownDescription": "To update a custom attribute, the script must resolve to a hash object with `name`, `type` and `value` attributes. The supported custom attribute data types are `number`, `text`, `boolean` (checkbox), `date`, `datetime`, `file`, `image`, `physicalQuantity`, `relation`, and `duration`.\n\n\nSee more: [Update Resource Schema](https://schema.laboperator.com/schemas/definitions/workflow-template/action-objects/update-resource) "
                                                     }
                                                 }
                                             }
@@ -3177,7 +3177,7 @@
                             }
                         }
                     ],
-                    "markdownDescription": "An action to update a resource. It can be used to update the value of custom attributes.\nIn case of Workflow Runs also update their title and name of Device.\n\n\nSee more: [Update Resource Schema](https://schema.laboperator.com/schemas/definitions/workflow-template/action-objects/update-resource) "
+                    "markdownDescription": "An action to update the value of custom attributes of a resource, as well as the title of a Workflow Run, or the name of a Device.\n\n\nSee more: [Update Resource Schema](https://schema.laboperator.com/schemas/definitions/workflow-template/action-objects/update-resource) "
                 },
                 "webhook": {
                     "type": "object",

--- a/dist/workflow-template-schema.json
+++ b/dist/workflow-template-schema.json
@@ -3124,7 +3124,6 @@
                                                     "collection",
                                                     "connector",
                                                     "dashboard",
-                                                    "device",
                                                     "export",
                                                     "measurement",
                                                     "sample",

--- a/dist/workflow-template-schema.json
+++ b/dist/workflow-template-schema.json
@@ -3024,7 +3024,7 @@
                 "update-resource": {
                     "type": "object",
                     "title": "Update Resource",
-                    "description": "An action to update a resource. It can be used to update the value of custom attributes, and in case of Workflow Runs also update their title.\n",
+                    "description": "An action to update a resource. It can be used to update the value of custom attributes.\nIn case of Workflow Runs also update their title and name of Device.\n",
                     "propertyNames": {
                         "enum": [
                             "update_resource",
@@ -3053,6 +3053,35 @@
                             },
                             {
                                 "oneOf": [
+                                    {
+                                        "type": "object",
+                                        "required": [
+                                            "type",
+                                            "attributes"
+                                        ],
+                                        "properties": {
+                                            "type": {
+                                                "type": "string",
+                                                "enum": [
+                                                    "device"
+                                                ]
+                                            },
+                                            "attributes": {
+                                                "type": "object",
+                                                "additionalProperties": false,
+                                                "properties": {
+                                                    "custom_attributes": {
+                                                        "$ref": "#/definitions/script",
+                                                        "description": "To update a custom attribute, the script must resolve to a hash object with `name`, `type` and `value` attributes. The supported custom attribute data types are `number`, `text`, `boolean` (checkbox), `date`, `datetime`, `file`, `image`, `physicalQuantity`, `relation`, and `duration`.\n",
+                                                        "markdownDescription": "To update a custom attribute, the script must resolve to a hash object with `name`, `type` and `value` attributes. The supported custom attribute data types are `number`, `text`, `boolean` (checkbox), `date`, `datetime`, `file`, `image`, `physicalQuantity`, `relation`, and `duration`.\n\n\nSee more: [Update Resource Schema](https://schema.laboperator.com/schemas/definitions/workflow-template/action-objects/update-resource) "
+                                                    },
+                                                    "name": {
+                                                        "$ref": "#/definitions/script"
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    },
                                     {
                                         "type": "object",
                                         "required": [
@@ -3123,6 +3152,15 @@
                     "examples": [
                         {
                             "update_resource": {
+                                "id": "balance.id",
+                                "type": "device",
+                                "attributes": {
+                                    "name": "deviceField.name"
+                                }
+                            }
+                        },
+                        {
+                            "update_resource": {
                                 "id": "workflow_run.data.id",
                                 "type": "workflow_run",
                                 "attributes": {
@@ -3140,7 +3178,7 @@
                             }
                         }
                     ],
-                    "markdownDescription": "An action to update a resource. It can be used to update the value of custom attributes, and in case of Workflow Runs also update their title.\n\n\nSee more: [Update Resource Schema](https://schema.laboperator.com/schemas/definitions/workflow-template/action-objects/update-resource) "
+                    "markdownDescription": "An action to update a resource. It can be used to update the value of custom attributes.\nIn case of Workflow Runs also update their title and name of Device.\n\n\nSee more: [Update Resource Schema](https://schema.laboperator.com/schemas/definitions/workflow-template/action-objects/update-resource) "
                 },
                 "webhook": {
                     "type": "object",

--- a/src/schemata/definitions/workflow-template/action-objects/update-resource.yml
+++ b/src/schemata/definitions/workflow-template/action-objects/update-resource.yml
@@ -2,7 +2,8 @@
 type: object
 title: Update Resource
 description: |
-  An action to update a resource. It can be used to update the value of custom attributes, and in case of Workflow Runs also update their title.
+  An action to update a resource. It can be used to update the value of custom attributes.
+  In case of Workflow Runs also update their title and name of Device.
 propertyNames:
   enum:
     - update_resource
@@ -21,6 +22,24 @@ additionalProperties:
             - workflow_run.data.id
             - deviceField.id
     - oneOf:
+        - type: object
+          required:
+            - type
+            - attributes
+          properties:
+            type:
+              type: string
+              enum: [device]
+            attributes:
+              type: object
+              additionalProperties: false
+              properties:
+                custom_attributes:
+                  $ref: '#/definitions/script'
+                  description: |
+                    To update a custom attribute, the script must resolve to a hash object with `name`, `type` and `value` attributes. The supported custom attribute data types are `number`, `text`, `boolean` (checkbox), `date`, `datetime`, `file`, `image`, `physicalQuantity`, `relation`, and `duration`.
+                name:
+                  $ref: '#/definitions/script'
         - type: object
           required:
             - type
@@ -54,7 +73,7 @@ additionalProperties:
                 - export
                 - measurement
                 - sample
-                - workflow_step_template 
+                - workflow_step_template
                 - workflow_template
             attributes:
               type: object
@@ -65,6 +84,11 @@ additionalProperties:
                   description: |
                     To update a custom attribute, the script must evaluate to a hash object with `name`, `type` and `value` attributes. The supported custom attribute data types are `number`, `text`, `boolean` (checkbox), `date`, `datetime`, `file`, `image`, `physicalQuantity`, `relation`, and `duration`.
 examples:
+  - update_resource:
+      id: balance.id
+      type: device
+      attributes:
+        name: deviceField.name
   - update_resource:
       id: workflow_run.data.id
       type: workflow_run

--- a/src/schemata/definitions/workflow-template/action-objects/update-resource.yml
+++ b/src/schemata/definitions/workflow-template/action-objects/update-resource.yml
@@ -69,7 +69,6 @@ additionalProperties:
                 - collection
                 - connector
                 - dashboard
-                - device
                 - export
                 - measurement
                 - sample

--- a/src/schemata/definitions/workflow-template/action-objects/update-resource.yml
+++ b/src/schemata/definitions/workflow-template/action-objects/update-resource.yml
@@ -2,8 +2,7 @@
 type: object
 title: Update Resource
 description: |
-  An action to update a resource. It can be used to update the value of custom attributes.
-  In case of Workflow Runs also update their title and name of Device.
+  An action to update the value of custom attributes of a resource, as well as the title of a Workflow Run, or the name of a Device.
 propertyNames:
   enum:
     - update_resource
@@ -34,7 +33,7 @@ additionalProperties:
               type: object
               additionalProperties: false
               properties:
-                custom_attributes:
+                custom_attributes: &custom_attributes
                   $ref: '#/definitions/script'
                   description: |
                     To update a custom attribute, the script must resolve to a hash object with `name`, `type` and `value` attributes. The supported custom attribute data types are `number`, `text`, `boolean` (checkbox), `date`, `datetime`, `file`, `image`, `physicalQuantity`, `relation`, and `duration`.
@@ -52,10 +51,7 @@ additionalProperties:
               type: object
               additionalProperties: false
               properties:
-                custom_attributes:
-                  $ref: '#/definitions/script'
-                  description: |
-                    To update a custom attribute, the script must resolve to a hash object with `name`, `type` and `value` attributes. The supported custom attribute data types are `number`, `text`, `boolean` (checkbox), `date`, `datetime`, `file`, `image`, `physicalQuantity`, `relation`, and `duration`.
+                custom_attributes: *custom_attributes
                 title:
                   $ref: '#/definitions/script'
         - type: object
@@ -78,10 +74,7 @@ additionalProperties:
               type: object
               additionalProperties: false
               properties:
-                custom_attributes:
-                  $ref: '#/definitions/script'
-                  description: |
-                    To update a custom attribute, the script must evaluate to a hash object with `name`, `type` and `value` attributes. The supported custom attribute data types are `number`, `text`, `boolean` (checkbox), `date`, `datetime`, `file`, `image`, `physicalQuantity`, `relation`, and `duration`.
+                custom_attributes: *custom_attributes
 examples:
   - update_resource:
       id: balance.id

--- a/src/workflow-step-template-schema.json
+++ b/src/workflow-step-template-schema.json
@@ -1893,7 +1893,7 @@
         "update-resource": {
           "type": "object",
           "title": "Update Resource",
-          "description": "An action to update a resource. It can be used to update the value of custom attributes, and in case of Workflow Runs also update their title.\n",
+          "description": "An action to update a resource. It can be used to update the value of custom attributes.\nIn case of Workflow Runs also update their title and name of Device.\n",
           "propertyNames": {
             "enum": [
               "update_resource",
@@ -1922,6 +1922,35 @@
               },
               {
                 "oneOf": [
+                  {
+                    "type": "object",
+                    "required": [
+                      "type",
+                      "attributes"
+                    ],
+                    "properties": {
+                      "type": {
+                        "type": "string",
+                        "enum": [
+                          "device"
+                        ]
+                      },
+                      "attributes": {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                          "custom_attributes": {
+                            "$ref": "#/definitions/script",
+                            "description": "To update a custom attribute, the script must resolve to a hash object with `name`, `type` and `value` attributes. The supported custom attribute data types are `number`, `text`, `boolean` (checkbox), `date`, `datetime`, `file`, `image`, `physicalQuantity`, `relation`, and `duration`.\n",
+                            "markdownDescription": "To update a custom attribute, the script must resolve to a hash object with `name`, `type` and `value` attributes. The supported custom attribute data types are `number`, `text`, `boolean` (checkbox), `date`, `datetime`, `file`, `image`, `physicalQuantity`, `relation`, and `duration`.\n\n\nSee more: [Update Resource Schema](https://schema.laboperator.com/schemas/definitions/workflow-template/action-objects/update-resource) "
+                          },
+                          "name": {
+                            "$ref": "#/definitions/script"
+                          }
+                        }
+                      }
+                    }
+                  },
                   {
                     "type": "object",
                     "required": [
@@ -1992,6 +2021,15 @@
           "examples": [
             {
               "update_resource": {
+                "id": "balance.id",
+                "type": "device",
+                "attributes": {
+                  "name": "deviceField.name"
+                }
+              }
+            },
+            {
+              "update_resource": {
                 "id": "workflow_run.data.id",
                 "type": "workflow_run",
                 "attributes": {
@@ -2009,7 +2047,7 @@
               }
             }
           ],
-          "markdownDescription": "An action to update a resource. It can be used to update the value of custom attributes, and in case of Workflow Runs also update their title.\n\n\nSee more: [Update Resource Schema](https://schema.laboperator.com/schemas/definitions/workflow-template/action-objects/update-resource) "
+          "markdownDescription": "An action to update a resource. It can be used to update the value of custom attributes.\nIn case of Workflow Runs also update their title and name of Device.\n\n\nSee more: [Update Resource Schema](https://schema.laboperator.com/schemas/definitions/workflow-template/action-objects/update-resource) "
         },
         "webhook": {
           "type": "object",

--- a/src/workflow-step-template-schema.json
+++ b/src/workflow-step-template-schema.json
@@ -1893,7 +1893,7 @@
         "update-resource": {
           "type": "object",
           "title": "Update Resource",
-          "description": "An action to update a resource. It can be used to update the value of custom attributes.\nIn case of Workflow Runs also update their title and name of Device.\n",
+          "description": "An action to update the value of custom attributes of a resource, as well as the title of a Workflow Run, or the name of a Device.\n",
           "propertyNames": {
             "enum": [
               "update_resource",
@@ -2006,8 +2006,8 @@
                         "properties": {
                           "custom_attributes": {
                             "$ref": "#/definitions/script",
-                            "description": "To update a custom attribute, the script must evaluate to a hash object with `name`, `type` and `value` attributes. The supported custom attribute data types are `number`, `text`, `boolean` (checkbox), `date`, `datetime`, `file`, `image`, `physicalQuantity`, `relation`, and `duration`.\n",
-                            "markdownDescription": "To update a custom attribute, the script must evaluate to a hash object with `name`, `type` and `value` attributes. The supported custom attribute data types are `number`, `text`, `boolean` (checkbox), `date`, `datetime`, `file`, `image`, `physicalQuantity`, `relation`, and `duration`.\n\n\nSee more: [Update Resource Schema](https://schema.laboperator.com/schemas/definitions/workflow-template/action-objects/update-resource) "
+                            "description": "To update a custom attribute, the script must resolve to a hash object with `name`, `type` and `value` attributes. The supported custom attribute data types are `number`, `text`, `boolean` (checkbox), `date`, `datetime`, `file`, `image`, `physicalQuantity`, `relation`, and `duration`.\n",
+                            "markdownDescription": "To update a custom attribute, the script must resolve to a hash object with `name`, `type` and `value` attributes. The supported custom attribute data types are `number`, `text`, `boolean` (checkbox), `date`, `datetime`, `file`, `image`, `physicalQuantity`, `relation`, and `duration`.\n\n\nSee more: [Update Resource Schema](https://schema.laboperator.com/schemas/definitions/workflow-template/action-objects/update-resource) "
                           }
                         }
                       }
@@ -2046,7 +2046,7 @@
               }
             }
           ],
-          "markdownDescription": "An action to update a resource. It can be used to update the value of custom attributes.\nIn case of Workflow Runs also update their title and name of Device.\n\n\nSee more: [Update Resource Schema](https://schema.laboperator.com/schemas/definitions/workflow-template/action-objects/update-resource) "
+          "markdownDescription": "An action to update the value of custom attributes of a resource, as well as the title of a Workflow Run, or the name of a Device.\n\n\nSee more: [Update Resource Schema](https://schema.laboperator.com/schemas/definitions/workflow-template/action-objects/update-resource) "
         },
         "webhook": {
           "type": "object",

--- a/src/workflow-step-template-schema.json
+++ b/src/workflow-step-template-schema.json
@@ -1993,7 +1993,6 @@
                           "collection",
                           "connector",
                           "dashboard",
-                          "device",
                           "export",
                           "measurement",
                           "sample",

--- a/src/workflow-template-schema.json
+++ b/src/workflow-template-schema.json
@@ -3124,7 +3124,6 @@
                           "collection",
                           "connector",
                           "dashboard",
-                          "device",
                           "export",
                           "measurement",
                           "sample",

--- a/src/workflow-template-schema.json
+++ b/src/workflow-template-schema.json
@@ -3024,7 +3024,7 @@
         "update-resource": {
           "type": "object",
           "title": "Update Resource",
-          "description": "An action to update a resource. It can be used to update the value of custom attributes.\nIn case of Workflow Runs also update their title and name of Device.\n",
+          "description": "An action to update the value of custom attributes of a resource, as well as the title of a Workflow Run, or the name of a Device.\n",
           "propertyNames": {
             "enum": [
               "update_resource",
@@ -3137,8 +3137,8 @@
                         "properties": {
                           "custom_attributes": {
                             "$ref": "#/definitions/script",
-                            "description": "To update a custom attribute, the script must evaluate to a hash object with `name`, `type` and `value` attributes. The supported custom attribute data types are `number`, `text`, `boolean` (checkbox), `date`, `datetime`, `file`, `image`, `physicalQuantity`, `relation`, and `duration`.\n",
-                            "markdownDescription": "To update a custom attribute, the script must evaluate to a hash object with `name`, `type` and `value` attributes. The supported custom attribute data types are `number`, `text`, `boolean` (checkbox), `date`, `datetime`, `file`, `image`, `physicalQuantity`, `relation`, and `duration`.\n\n\nSee more: [Update Resource Schema](https://schema.laboperator.com/schemas/definitions/workflow-template/action-objects/update-resource) "
+                            "description": "To update a custom attribute, the script must resolve to a hash object with `name`, `type` and `value` attributes. The supported custom attribute data types are `number`, `text`, `boolean` (checkbox), `date`, `datetime`, `file`, `image`, `physicalQuantity`, `relation`, and `duration`.\n",
+                            "markdownDescription": "To update a custom attribute, the script must resolve to a hash object with `name`, `type` and `value` attributes. The supported custom attribute data types are `number`, `text`, `boolean` (checkbox), `date`, `datetime`, `file`, `image`, `physicalQuantity`, `relation`, and `duration`.\n\n\nSee more: [Update Resource Schema](https://schema.laboperator.com/schemas/definitions/workflow-template/action-objects/update-resource) "
                           }
                         }
                       }
@@ -3177,7 +3177,7 @@
               }
             }
           ],
-          "markdownDescription": "An action to update a resource. It can be used to update the value of custom attributes.\nIn case of Workflow Runs also update their title and name of Device.\n\n\nSee more: [Update Resource Schema](https://schema.laboperator.com/schemas/definitions/workflow-template/action-objects/update-resource) "
+          "markdownDescription": "An action to update the value of custom attributes of a resource, as well as the title of a Workflow Run, or the name of a Device.\n\n\nSee more: [Update Resource Schema](https://schema.laboperator.com/schemas/definitions/workflow-template/action-objects/update-resource) "
         },
         "webhook": {
           "type": "object",

--- a/src/workflow-template-schema.json
+++ b/src/workflow-template-schema.json
@@ -3024,7 +3024,7 @@
         "update-resource": {
           "type": "object",
           "title": "Update Resource",
-          "description": "An action to update a resource. It can be used to update the value of custom attributes, and in case of Workflow Runs also update their title.\n",
+          "description": "An action to update a resource. It can be used to update the value of custom attributes.\nIn case of Workflow Runs also update their title and name of Device.\n",
           "propertyNames": {
             "enum": [
               "update_resource",
@@ -3053,6 +3053,35 @@
               },
               {
                 "oneOf": [
+                  {
+                    "type": "object",
+                    "required": [
+                      "type",
+                      "attributes"
+                    ],
+                    "properties": {
+                      "type": {
+                        "type": "string",
+                        "enum": [
+                          "device"
+                        ]
+                      },
+                      "attributes": {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                          "custom_attributes": {
+                            "$ref": "#/definitions/script",
+                            "description": "To update a custom attribute, the script must resolve to a hash object with `name`, `type` and `value` attributes. The supported custom attribute data types are `number`, `text`, `boolean` (checkbox), `date`, `datetime`, `file`, `image`, `physicalQuantity`, `relation`, and `duration`.\n",
+                            "markdownDescription": "To update a custom attribute, the script must resolve to a hash object with `name`, `type` and `value` attributes. The supported custom attribute data types are `number`, `text`, `boolean` (checkbox), `date`, `datetime`, `file`, `image`, `physicalQuantity`, `relation`, and `duration`.\n\n\nSee more: [Update Resource Schema](https://schema.laboperator.com/schemas/definitions/workflow-template/action-objects/update-resource) "
+                          },
+                          "name": {
+                            "$ref": "#/definitions/script"
+                          }
+                        }
+                      }
+                    }
+                  },
                   {
                     "type": "object",
                     "required": [
@@ -3123,6 +3152,15 @@
           "examples": [
             {
               "update_resource": {
+                "id": "balance.id",
+                "type": "device",
+                "attributes": {
+                  "name": "deviceField.name"
+                }
+              }
+            },
+            {
+              "update_resource": {
                 "id": "workflow_run.data.id",
                 "type": "workflow_run",
                 "attributes": {
@@ -3140,7 +3178,7 @@
               }
             }
           ],
-          "markdownDescription": "An action to update a resource. It can be used to update the value of custom attributes, and in case of Workflow Runs also update their title.\n\n\nSee more: [Update Resource Schema](https://schema.laboperator.com/schemas/definitions/workflow-template/action-objects/update-resource) "
+          "markdownDescription": "An action to update a resource. It can be used to update the value of custom attributes.\nIn case of Workflow Runs also update their title and name of Device.\n\n\nSee more: [Update Resource Schema](https://schema.laboperator.com/schemas/definitions/workflow-template/action-objects/update-resource) "
         },
         "webhook": {
           "type": "object",


### PR DESCRIPTION
### [CUB-5083]

### Manual PR Checklist

- [x] CHANGELOG entry added
- [x] ~Test coverage added~
- [x] Licenses checked
- [x] All related Jira tickets added to PR title
- [x] Description in Jira ticket is clear and up-to-date


[CUB-5083]: https://labforward.atlassian.net/browse/CUB-5083?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ